### PR TITLE
Add publish test report github action

### DIFF
--- a/.github/workflows/publish_test_report.yml
+++ b/.github/workflows/publish_test_report.yml
@@ -1,0 +1,20 @@
+name: 'Test Report'
+on:
+  workflow_run:
+    workflows: []
+    types:
+      - completed
+permissions:
+  contents: read
+  actions: read
+  checks: write
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dorny/test-reporter@v1
+      with:
+        artifact: test_sparrow_lib_report_(.*)
+        name: Process test report
+        path: '**/*.xml'
+        reporter: java-junit


### PR DESCRIPTION
This PR is to unlock the branch the improve the reporting of the UT reports as the workflow which depends on another workflow must be on the default branch.