### PR TITLE
factory function refactor

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,6 +2,7 @@
 SET(EXAMPLES 
     typed_array_low_level.cpp
     typed_array_high_level.cpp
+    sandbox.cpp
 )
 
 # iterate over all examples

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,7 +2,6 @@
 SET(EXAMPLES 
     typed_array_low_level.cpp
     typed_array_high_level.cpp
-    sandbox.cpp
 )
 
 # iterate over all examples

--- a/examples/typed_array_high_level.cpp
+++ b/examples/typed_array_high_level.cpp
@@ -8,8 +8,8 @@
 
 
 void example_typed_array_of_floats(){
-    using value_type = bool;
-    std::vector<value_type> data = {true, false, true, false, true};
+    using value_type = float;
+    std::vector<value_type> data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
     
     // construct the array
     auto array = sparrow::typed_array<value_type>(data);
@@ -25,7 +25,7 @@ void example_typed_array_of_floats(){
     }
 }
 
-/*
+
 void example_typed_array_of_strings(){
     using value_type = std::string;
     std::vector<std::string> data = {
@@ -49,7 +49,7 @@ void example_typed_array_of_strings(){
         }
     }
 }
-
+/*
 void example_typed_array_of_strings_from_nullables(){
 
     using value_type = std::string;
@@ -78,7 +78,7 @@ void example_typed_array_of_strings_from_nullables(){
 }*/
 int main() {
     example_typed_array_of_floats();
-    //example_typed_array_of_strings();
+    example_typed_array_of_strings();
     //example_typed_array_of_strings_from_nullables();
     return 0;
 }

--- a/examples/typed_array_high_level.cpp
+++ b/examples/typed_array_high_level.cpp
@@ -7,9 +7,9 @@
 #include <sparrow/array.hpp>
 
 
-/*void example_typed_array_of_floats(){
-    using value_type = float;
-    std::vector<value_type> data = {1.0, 2.0, 3.0, 4.0, 5.0};
+void example_typed_array_of_floats(){
+    using value_type = bool;
+    std::vector<value_type> data = {true, false, true, false, true};
     
     // construct the array
     auto array = sparrow::typed_array<value_type>(data);
@@ -25,6 +25,7 @@
     }
 }
 
+/*
 void example_typed_array_of_strings(){
     using value_type = std::string;
     std::vector<std::string> data = {
@@ -76,7 +77,7 @@ void example_typed_array_of_strings_from_nullables(){
     }
 }*/
 int main() {
-    //example_typed_array_of_floats();
+    example_typed_array_of_floats();
     //example_typed_array_of_strings();
     //example_typed_array_of_strings_from_nullables();
     return 0;

--- a/include/sparrow/array/array_data.hpp
+++ b/include/sparrow/array/array_data.hpp
@@ -35,6 +35,8 @@ namespace sparrow
      */
     struct array_data
     {
+        // is the data in buffers allowed to be modified?
+        static constexpr bool is_mutable = true;
         using block_type = std::uint8_t;
         using bitmap_type = dynamic_bitset<block_type>;
         using buffer_type = buffer<block_type>;

--- a/include/sparrow/array/array_data_concepts.hpp
+++ b/include/sparrow/array/array_data_concepts.hpp
@@ -63,6 +63,7 @@ namespace sparrow
     template <class T>
     concept data_storage = requires(T t, std::size_t i)
     {
+        { T::is_mutable } -> std::convertible_to<bool>;
         { type_descriptor(t) } -> std::same_as<data_descriptor>;
         { length(t) } -> std::same_as<std::int64_t>;
         { offset(t) } -> std::same_as<std::int64_t>;
@@ -72,6 +73,7 @@ namespace sparrow
         { child_data_size(t) } -> std::same_as<std::size_t>;
         child_data_at(t, i);
         dictionary(t);
+
     };
 
 }  // namespace sparrow

--- a/include/sparrow/array/array_data_concepts.hpp
+++ b/include/sparrow/array/array_data_concepts.hpp
@@ -73,7 +73,6 @@ namespace sparrow
         { child_data_size(t) } -> std::same_as<std::size_t>;
         child_data_at(t, i);
         dictionary(t);
-
     };
 
 }  // namespace sparrow

--- a/include/sparrow/array/array_data_factory.hpp
+++ b/include/sparrow/array/array_data_factory.hpp
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <iostream> // REMOVE ME
+
+#include <ranges>
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -126,7 +129,7 @@ namespace sparrow
      * @param offset The offset of the array data.
      * @return The created array_data object.
      */
-    template <constant_range_for_array_data ValueRange>
+    template <range_for_array_data ValueRange>
     array_data make_array_data_for_fixed_size_layout(
         ValueRange&& values,
         const array_data::bitmap_type& bitmap,
@@ -137,13 +140,18 @@ namespace sparrow
         // Check that the range is a range of ranges
         if constexpr (std::ranges::range<T>)
         {
+            std::cout<<"is range"<<std::endl;
             SPARROW_ASSERT_TRUE(check_all_elements_have_same_size(values));
         }
+
+        std::cout<<"values.size(): "<<values.size()<<std::endl;
+        std::cout<<"bitmap.size(): "<<bitmap.size()<<std::endl;
         SPARROW_ASSERT_TRUE(values.size() == bitmap.size());
         SPARROW_ASSERT_TRUE(std::cmp_greater_equal(values.size(), offset));
 
         const auto create_buffer = [&values]()
         {
+            std::cout<<"create_buffer"<<std::endl;
             const size_t buffer_size = (values.size() * sizeof(T)) / sizeof(uint8_t);
             array_data::buffer_type buffer(buffer_size);
             auto data = buffer.data<T>();
@@ -152,9 +160,11 @@ namespace sparrow
                 *data = value;
                 ++data;
             }
+            std::cout<<"buffer_size: "<<buffer_size<<std::endl;
             return buffer;
         };
         using U = std::conditional_t<std::same_as<T, std::string_view>, std::string, T>;
+
         return {
             .type = data_descriptor(arrow_type_id<U>()),
             .length = static_cast<int64_t>(values.size()),
@@ -198,7 +208,7 @@ namespace sparrow
      * @param offset The offset of the array_data object.
      * @return The created array_data object.
      */
-    template <constant_range_for_array_data ValueRange>
+    template <range_for_array_data ValueRange>
     array_data make_array_data_for_variable_size_binary_layout(
         ValueRange&& values,
         const array_data::bitmap_type& bitmap,
@@ -254,7 +264,7 @@ namespace sparrow
 
         using T = std::unwrap_ref_decay_t<std::unwrap_ref_decay_t<std::ranges::range_value_t<ValueRange>>>;
         using U = get_corresponding_arrow_type_t<T>;
-
+        std::cout<<"return..."<<std::endl;
         return {
             .type = data_descriptor(arrow_type_id<U>()),
             .length = static_cast<array_data::length_type>(values.size()),
@@ -374,7 +384,7 @@ namespace sparrow
      * @param offset The offset for the array data.
      * @return The created array_data object.
      */
-    template <constant_range_for_array_data ValueRange>
+    template <range_for_array_data ValueRange>
     array_data make_array_data_for_dictionary_encoded_layout(
         ValueRange&& values,
         const array_data::bitmap_type& bitmap,
@@ -461,10 +471,11 @@ namespace sparrow
      * @param offset The offset for the array data.
      * @return The created array data object.
      */
-    template <arrow_layout Layout, constant_range_for_array_data ValueRange>
+    template <arrow_layout Layout, range_for_array_data ValueRange>
     array_data
     make_default_array_data(ValueRange&& values, const array_data::bitmap_type& bitmap, std::int64_t offset)
     {
+        std::cout<<"make_default_array_data for const range"<<std::endl;
         if constexpr (mpl::is_type_instance_of_v<Layout, fixed_size_layout>)
         {
             return make_array_data_for_fixed_size_layout(std::forward<ValueRange>(values), bitmap, offset);
@@ -487,23 +498,24 @@ namespace sparrow
         }
     }
 
-    /**
-     * \brief Creates a default array_data object with the specified layout and values.
-     *
-     * @tparam Layout The layout of the array_data object.
-     * @tparam ValueRange The type of the input range for the values.
-     * @param values The input range of values for the array_data object.
-     * @param bitmap The bitmap type for the array_data object.
-     * @param offset The offset for the array_data object.
-     * @return A new array_data object with the specified layout, values, bitmap, and offset.
-     */
-    template <arrow_layout Layout, std::ranges::input_range ValueRange>
-        requires(!mpl::constant_range<ValueRange>)
-    array_data
-    make_default_array_data(ValueRange&& values, const array_data::bitmap_type& bitmap, std::int64_t offset)
-    {
-        return make_default_array_data<Layout>(std::as_const(values), bitmap, offset);
-    }
+    // /**
+    //  * \brief Creates a default array_data object with the specified layout and values.
+    //  *
+    //  * @tparam Layout The layout of the array_data object.
+    //  * @tparam ValueRange The type of the input range for the values.
+    //  * @param values The input range of values for the array_data object.
+    //  * @param bitmap The bitmap type for the array_data object.
+    //  * @param offset The offset for the array_data object.
+    //  * @return A new array_data object with the specified layout, values, bitmap, and offset.
+    //  */
+    // template <arrow_layout Layout, std::ranges::input_range ValueRange>
+    //     requires(!mpl::constant_range<ValueRange>)
+    // array_data
+    // make_default_array_data_nc(ValueRange&& values, const array_data::bitmap_type& bitmap, std::int64_t offset)
+    // {
+    //     std::cout<<"make_default_array_data for NON-const range"<<std::endl;
+    //     return make_default_array_data_c<Layout>(std::as_const(values), bitmap, offset);
+    // }
 
 
 
@@ -517,12 +529,14 @@ namespace sparrow
      * @return A new array_data object with the specified layout, values, bitmap, and offset.
      */
     template <arrow_layout Layout, std::ranges::input_range ValueRange>
-        requires(!mpl::constant_range<ValueRange>)
     array_data
     make_default_array_data(ValueRange&& values)
     {
+        std::cout<<"make_default_array_data"<<std::endl;
         // size of the range
         const std::size_t size = std::ranges::size(values);
+
+        std::cout<<"    size: "<<size<<std::endl;
 
         // create a bitmap with all values set to true
         array_data::bitmap_type bitmap(size, true);
@@ -530,6 +544,7 @@ namespace sparrow
         // zero offset
         const std::int64_t offset = 0;
 
+        std::cout<<"    call make_default_array_data(values, bitmap, offset)"<<std::endl;
         return make_default_array_data<Layout>(std::as_const(values), bitmap, offset);
     }
 }  // namespace sparrow

--- a/include/sparrow/array/array_data_factory.hpp
+++ b/include/sparrow/array/array_data_factory.hpp
@@ -504,4 +504,32 @@ namespace sparrow
     {
         return make_default_array_data<Layout>(std::as_const(values), bitmap, offset);
     }
+
+
+
+
+    /**
+     * \brief Creates a default array_data object with the specified layout and values.
+     *
+     * @tparam Layout The layout of the array_data object.
+     * @tparam ValueRange The type of the input range for the values.
+     * @param values The input range of values for the array_data object.
+     * @return A new array_data object with the specified layout, values, bitmap, and offset.
+     */
+    template <arrow_layout Layout, std::ranges::input_range ValueRange>
+        requires(!mpl::constant_range<ValueRange>)
+    array_data
+    make_default_array_data(ValueRange&& values)
+    {
+        // size of the range
+        const std::size_t size = std::ranges::size(values);
+
+        // create a bitmap with all values set to true
+        array_data::bitmap_type bitmap(size, true);
+
+        // zero offset
+        const std::int64_t offset = 0;
+
+        return make_default_array_data<Layout>(std::as_const(values), bitmap, offset);
+    }
 }  // namespace sparrow

--- a/include/sparrow/array/array_data_factory.hpp
+++ b/include/sparrow/array/array_data_factory.hpp
@@ -507,4 +507,27 @@ namespace sparrow
         const std::int64_t offset = 0;
         return make_default_array_data<Layout>(std::forward<ValueRange>(values), std::move(bitmap), offset);
     }
+
+
+    /**
+     * \brief Creates a default array_data object with the specified layout and values.
+     * 
+     * @tparam Layout The layout of the array_data object.
+     * @tparam T The type of the value to be repeated.
+     * 
+     * @param n The number of times the value should be repeated.
+     * @param value The value to be repeated.
+     */
+    template <arrow_layout Layout, class T>
+    requires is_arrow_base_type_extended<std::decay_t<T>>
+    array_data make_default_array_data( 
+        typename Layout::size_type n
+        ,  T && value)
+    {
+        auto repeated_range = std::ranges::iota_view{size_t(0),size_t(n)} | std::views::transform([&](auto) { return value; });
+
+        return make_default_array_data<Layout>(repeated_range);
+    }
+
+
 }  // namespace sparrow

--- a/include/sparrow/array/external_array_data.hpp
+++ b/include/sparrow/array/external_array_data.hpp
@@ -96,6 +96,10 @@ namespace sparrow
     {
     public:
 
+        // is the data in buffers allowed to be modified?
+        static constexpr bool is_mutable = false;
+
+
         using block_type = std::uint8_t;
         using bitmap_type = dynamic_bitset_view<const block_type>;
         using buffer_type = buffer_view<const block_type>;

--- a/include/sparrow/array/external_array_data.hpp
+++ b/include/sparrow/array/external_array_data.hpp
@@ -96,10 +96,7 @@ namespace sparrow
     {
     public:
 
-        // is the data in buffers allowed to be modified?
         static constexpr bool is_mutable = false;
-
-
         using block_type = std::uint8_t;
         using bitmap_type = dynamic_bitset_view<const block_type>;
         using buffer_type = buffer_view<const block_type>;

--- a/include/sparrow/array/typed_array.hpp
+++ b/include/sparrow/array/typed_array.hpp
@@ -97,10 +97,10 @@ namespace sparrow
         typed_array_impl& operator=(typed_array_impl&& rhs);
         ///@}
 
-        // /** Construct a typed array from a range of values.
-        //  * 
-        //  * @param values The range of values to construct the array from.
-        //  */
+        /** Construct a typed array from a range of values.
+         * 
+         * @param values The range of values to construct the array from.
+         */
         template <std::ranges::input_range ValueRange>
         requires  
             range_for_array_data<ValueRange> && 

--- a/include/sparrow/array/typed_array.hpp
+++ b/include/sparrow/array/typed_array.hpp
@@ -233,8 +233,8 @@ namespace sparrow
 
     private:
 
-        data_storage_type m_data;// = make_default_array_data<L>();
-        layout_type m_layout;//{m_data};
+        data_storage_type m_data;
+        layout_type m_layout;
     };
 
     template <class T, class Layout>

--- a/include/sparrow/array/typed_array.hpp
+++ b/include/sparrow/array/typed_array.hpp
@@ -328,7 +328,7 @@ namespace sparrow
     template<class U>
     requires is_arrow_base_type_extended<std::decay_t<U>>
     typed_array_impl<T, L>::typed_array_impl(size_type n,  U&& value)
-        : m_data(make_default_array_data<L>(n, value))
+        : m_data(make_default_array_data<L>(n, std::forward<U>(value)))
         , m_layout{m_data}
     {
     }

--- a/include/sparrow/array/typed_array.hpp
+++ b/include/sparrow/array/typed_array.hpp
@@ -106,11 +106,8 @@ namespace sparrow
             range_for_array_data<ValueRange> && 
             std::same_as<array_data, typename L::data_storage_type> &&
             (!is_typed_array_impl_v<ValueRange>)
-        typed_array_impl(ValueRange&& values)   
-            : m_data(make_default_array_data<L>(std::forward<ValueRange>(values)))
-            , m_layout(m_data) 
-        {
-        }
+        typed_array_impl(ValueRange&& values);
+
 
         /** Construct a typed array with a fixed layout with the same value repeated `n` times.
          *
@@ -305,7 +302,6 @@ namespace sparrow
         : m_data(make_default_array_data<L>())
         , m_layout{m_data}
     {
-        std::cout<<"typed_array_impl<T, L>::typed_array_impl()"<<std::endl;
     }
 
     template <is_arrow_base_type T, arrow_layout L>
@@ -315,17 +311,17 @@ namespace sparrow
     {
     }
 
-    // template <is_arrow_base_type T, arrow_layout L>
-    // template <std::ranges::input_range ValueRange>
-    // requires  
-    //     range_for_array_data<ValueRange> && 
-    //     std::same_as<array_data, typename L::data_storage_type> &&
-    //     (!is_typed_array_impl_v<ValueRange>)
-    // typed_array_impl<T, L>::typed_array_impl(ValueRange&& values)   
-    //     : m_data(make_default_array_data<L>(std::forward<ValueRange>(values)))
-    //     , m_layout(m_data) 
-    // {
-    // }
+    template <is_arrow_base_type T, arrow_layout L>
+    template <std::ranges::input_range ValueRange>
+    requires  
+        range_for_array_data<ValueRange> && 
+        std::same_as<array_data, typename L::data_storage_type> &&
+        (!is_typed_array_impl_v<ValueRange>)
+    typed_array_impl<T, L>::typed_array_impl(ValueRange&& values)   
+        : m_data(make_default_array_data<L>(std::forward<ValueRange>(values)))
+        , m_layout(m_data) 
+    {
+    }
 
 
 

--- a/include/sparrow/array/typed_array.hpp
+++ b/include/sparrow/array/typed_array.hpp
@@ -33,7 +33,7 @@ namespace sparrow
 {
 
     // forward declaration
-     template <is_arrow_base_type T, arrow_layout L>
+    template <is_arrow_base_type T, arrow_layout L>
     class typed_array_impl;
 
     /*

--- a/include/sparrow/layout/fixed_size_layout.hpp
+++ b/include/sparrow/layout/fixed_size_layout.hpp
@@ -47,7 +47,6 @@ namespace sparrow
     {
     public:
 
-
         using self_type = fixed_size_layout<T, DS>;
         using data_storage_type = DS;
         constexpr static bool is_mutable = data_storage_type::is_mutable;

--- a/include/sparrow/layout/fixed_size_layout.hpp
+++ b/include/sparrow/layout/fixed_size_layout.hpp
@@ -52,7 +52,7 @@ namespace sparrow
         using data_storage_type = DS;
         constexpr static bool is_mutable = data_storage_type::is_mutable;
         using inner_value_type = std::conditional_t<is_mutable, T, const T>;
-        using inner_reference = std::conditional_t<is_mutable, inner_value_type&, const inner_value_type&>;
+        using inner_reference = inner_value_type&;
         using inner_const_reference = const inner_value_type&;
         using bitmap_type = typename data_storage_type::bitmap_type;
         using bitmap_reference = typename bitmap_type::reference;

--- a/include/sparrow/layout/fixed_size_layout.hpp
+++ b/include/sparrow/layout/fixed_size_layout.hpp
@@ -47,10 +47,12 @@ namespace sparrow
     {
     public:
 
+
         using self_type = fixed_size_layout<T, DS>;
         using data_storage_type = DS;
-        using inner_value_type = T;
-        using inner_reference = inner_value_type&;
+        constexpr static bool is_mutable = data_storage_type::is_mutable;
+        using inner_value_type = std::conditional_t<is_mutable, T, const T>;
+        using inner_reference = std::conditional_t<is_mutable, inner_value_type&, const inner_value_type&>;
         using inner_const_reference = const inner_value_type&;
         using bitmap_type = typename data_storage_type::bitmap_type;
         using bitmap_reference = typename bitmap_type::reference;

--- a/include/sparrow/layout/variable_size_binary_layout.hpp
+++ b/include/sparrow/layout/variable_size_binary_layout.hpp
@@ -185,8 +185,9 @@ namespace sparrow
 
         using self_type = variable_size_binary_layout<T, CR, DS, OT>;
         using data_storage_type = DS;
+        constexpr static bool is_mutable = data_storage_type::is_mutable;
         using offset_type = OT;
-        using inner_value_type = T;
+        using inner_value_type = std::conditional_t<is_mutable, T, const T>; 
         using inner_reference = vs_binary_reference<self_type>;
         using inner_const_reference = CR;
         using bitmap_type = typename data_storage_type::bitmap_type;

--- a/test/test_array_data.cpp
+++ b/test/test_array_data.cpp
@@ -54,6 +54,7 @@ namespace sparrow
 
     struct test_array_data
     {
+        constexpr static bool is_mutable = true;
         using block_type = std::uint8_t;
         using bitmap_type = dynamic_bitset_view<const block_type>;
         using buffer_type = test::cast_vector<block_type>;

--- a/test/test_array_data.cpp
+++ b/test/test_array_data.cpp
@@ -54,7 +54,7 @@ namespace sparrow
 
     struct test_array_data
     {
-        constexpr static bool is_mutable = true;
+        constexpr static bool is_mutable = false;
         using block_type = std::uint8_t;
         using bitmap_type = dynamic_bitset_view<const block_type>;
         using buffer_type = test::cast_vector<block_type>;

--- a/test/test_typed_array.cpp
+++ b/test/test_typed_array.cpp
@@ -484,23 +484,21 @@ TEST_SUITE("typed_array")
 
     TEST_CASE_TEMPLATE_DEFINE("all_except_string",  T, all_except_string)
     {
-        // this constructor is not available for string on purpose
-        // because std::string is auto mapped to a variable_size_binary_layout 
-        // which defeats the purpose of this constructor
-        // SUBCASE("constructor_with_n_inital_value")
-        // {   
-        //     // get a "one" in a generic way with iota_vector of length 2 at index 1 =)
-        //     const auto data = test::iota_vector<T>(2);
-        //     const auto one = data[1];
 
-        //     const typed_array<T> ta{10, one};
-        //     CHECK_EQ(ta.size(), 10);
+        SUBCASE("constructor_with_n_inital_value")
+        {   
+            // get a "one" in a generic way with iota_vector of length 2 at index 1 =)
+            const auto data = test::iota_vector<T>(2);
+            T one = data[1];
 
-        //     for (size_t i = 0; i < ta.size(); ++i)
-        //     {
-        //         CHECK_EQ(ta[i].value(), one);
-        //     }
-        // }
+            const typed_array<T> ta{std::size_t(10), one};
+            CHECK_EQ(ta.size(), 10);
+
+            for (size_t i = 0; i < ta.size(); ++i)
+            {
+                CHECK_EQ(ta[i].value(), one);
+            }
+        }
     }
 
     TEST_CASE_TEMPLATE_INVOKE(

--- a/test/test_typed_array.cpp
+++ b/test/test_typed_array.cpp
@@ -30,9 +30,9 @@ using sparrow::test::to_value_type;
 
 namespace
 {
-    // constexpr size_t array_size = 10;
-    // constexpr size_t array_offset = 1;
-    // const std::vector<size_t> false_bitmap = {9};
+    constexpr size_t array_size = 10;
+    constexpr size_t array_offset = 1;
+    const std::vector<size_t> false_bitmap = {9};
 }
 
 namespace
@@ -53,20 +53,20 @@ namespace
 
 TEST_SUITE("typed_array")
 {
-    // TEST_CASE("default constructor for variable_size_binary_layout")
-    // {
-    //     using Layout = variable_size_binary_layout<std::string, const std::string_view>;
-    //     const typed_array<std::string, Layout> ta_for_vsbl;
-    //     CHECK_EQ(ta_for_vsbl.size(), 0);
-    // }
+    TEST_CASE("default constructor for variable_size_binary_layout")
+    {
+        using Layout = variable_size_binary_layout<std::string, const std::string_view>;
+        const typed_array<std::string, Layout> ta_for_vsbl;
+        CHECK_EQ(ta_for_vsbl.size(), 0);
+    }
 
-    // TEST_CASE("default constructor for dictionary_encoded_layout")
-    // {
-    //     using SubLayout = variable_size_binary_layout<std::string, const std::string_view>;
-    //     using Layout = dictionary_encoded_layout<std::uint32_t, SubLayout>;
-    //     typed_array<uint32_t, Layout> ta_for_dels;
-    //     CHECK_EQ(ta_for_dels.size(), 0);
-    // }
+    TEST_CASE("default constructor for dictionary_encoded_layout")
+    {
+        using SubLayout = variable_size_binary_layout<std::string, const std::string_view>;
+        using Layout = dictionary_encoded_layout<std::uint32_t, SubLayout>;
+        typed_array<uint32_t, Layout> ta_for_dels;
+        CHECK_EQ(ta_for_dels.size(), 0);
+    }
 
     /*TEST_CASE("constructor from range of nullable fixed_size_layout"){
         using nt = nullable<int32_t>;
@@ -185,38 +185,38 @@ TEST_SUITE("typed_array")
 
     TEST_CASE_TEMPLATE_DEFINE("all", T, all)
     {
-        // SUBCASE("default constructor for fixed_size_layout")
-        // {
-        //     using Layout = fixed_size_layout<int32_t>;
-        //     const typed_array<int32_t, Layout> ta_for_fsl;
-        //     CHECK_EQ(ta_for_fsl.size(), 0);
-        // }
+        SUBCASE("default constructor for fixed_size_layout")
+        {
+            using Layout = fixed_size_layout<int32_t>;
+            const typed_array<int32_t, Layout> ta_for_fsl;
+            CHECK_EQ(ta_for_fsl.size(), 0);
+        }
 
-        // SUBCASE("constructor with parameter")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
-        //     const typed_array<T> ta{array_data};
-        //     CHECK_EQ(ta.size(), array_size - array_offset);
-        // }
+        SUBCASE("constructor with parameter")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
+            const typed_array<T> ta{array_data};
+            CHECK_EQ(ta.size(), array_size - array_offset);
+        }
 
-        // SUBCASE("copy constructor")
-        // {
-        //     auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
-        //     typed_array<T> ta1{array_data};
-        //     typed_array<T> ta2(ta1);
+        SUBCASE("copy constructor")
+        {
+            auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
+            typed_array<T> ta1{array_data};
+            typed_array<T> ta2(ta1);
 
-        //     CHECK_EQ(ta1, ta2);
-        // }
+            CHECK_EQ(ta1, ta2);
+        }
 
-        // SUBCASE("move constructor")
-        // {
-        //     auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
-        //     typed_array<T> ta1{array_data};
-        //     typed_array<T> ta2(ta1);
-        //     typed_array<T> ta3(std::move(ta2));
+        SUBCASE("move constructor")
+        {
+            auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
+            typed_array<T> ta1{array_data};
+            typed_array<T> ta2(ta1);
+            typed_array<T> ta3(std::move(ta2));
 
-        //     CHECK_EQ(ta1, ta3);
-        // }
+            CHECK_EQ(ta1, ta3);
+        }
         SUBCASE("construct from range")
         {
             auto data = test::iota_vector<T>(10);
@@ -227,259 +227,259 @@ TEST_SUITE("typed_array")
                 CHECK_EQ(ta[i].value(), data[i]);
             }
         }
-        // SUBCASE("copy assignment")
-        // {
-        //     auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
-        //     typed_array<T> ta1{array_data};
+        SUBCASE("copy assignment")
+        {
+            auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
+            typed_array<T> ta1{array_data};
 
-        //     auto array_data2 = sparrow::test::make_test_array_data<T>(array_size + 8u, array_offset);
-        //     typed_array<T> ta2{array_data2};
+            auto array_data2 = sparrow::test::make_test_array_data<T>(array_size + 8u, array_offset);
+            typed_array<T> ta2{array_data2};
 
-        //     CHECK_NE(ta1, ta2);
+            CHECK_NE(ta1, ta2);
 
-        //     ta2 = ta1;
-        //     CHECK_EQ(ta1, ta2);
-        // }
+            ta2 = ta1;
+            CHECK_EQ(ta1, ta2);
+        }
 
-        // SUBCASE("move assignment")
-        // {
-        //     auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
-        //     typed_array<T> ta1{array_data};
-        //     typed_array<T> ta3{ta1};
+        SUBCASE("move assignment")
+        {
+            auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
+            typed_array<T> ta1{array_data};
+            typed_array<T> ta3{ta1};
 
-        //     auto array_data2 = sparrow::test::make_test_array_data<T>(array_size + 8u, array_offset);
-        //     typed_array<T> ta2{array_data2};
+            auto array_data2 = sparrow::test::make_test_array_data<T>(array_size + 8u, array_offset);
+            typed_array<T> ta2{array_data2};
 
-        //     CHECK_NE(ta1, ta2);
+            CHECK_NE(ta1, ta2);
 
-        //     ta2 = std::move(ta1);
-        //     CHECK_EQ(ta3, ta2);
-        // }
+            ta2 = std::move(ta1);
+            CHECK_EQ(ta3, ta2);
+        }
 
-        // // Element access
+        // Element access
 
-        // SUBCASE("at")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-        //     typed_array<T> ta{array_data};
-        //     for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++i)
-        //     {
-        //         CHECK_EQ(ta.at(i).value(), to_value_type<T>(i + array_offset));
-        //     }
-        //     CHECK_FALSE(ta.at(false_bitmap[0] - array_offset).has_value());
+        SUBCASE("at")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+            typed_array<T> ta{array_data};
+            for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++i)
+            {
+                CHECK_EQ(ta.at(i).value(), to_value_type<T>(i + array_offset));
+            }
+            CHECK_FALSE(ta.at(false_bitmap[0] - array_offset).has_value());
 
-        //     CHECK_THROWS_AS(ta.at(ta.size()), std::out_of_range);
-        // }
+            CHECK_THROWS_AS(ta.at(ta.size()), std::out_of_range);
+        }
 
-        // SUBCASE("const at")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-        //     const typed_array<T> ta{array_data};
-        //     for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++i)
-        //     {
-        //         CHECK_EQ(ta.at(i).value(), to_value_type<T>(i + array_offset));
-        //     }
-        //     CHECK_FALSE(ta.at(false_bitmap[0] - array_offset).has_value());
+        SUBCASE("const at")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+            const typed_array<T> ta{array_data};
+            for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++i)
+            {
+                CHECK_EQ(ta.at(i).value(), to_value_type<T>(i + array_offset));
+            }
+            CHECK_FALSE(ta.at(false_bitmap[0] - array_offset).has_value());
 
-        //     CHECK_THROWS_AS(ta.at(ta.size()), std::out_of_range);
-        // }
+            CHECK_THROWS_AS(ta.at(ta.size()), std::out_of_range);
+        }
 
-        // SUBCASE("operator[]")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-        //     typed_array<T> ta{array_data};
-        //     for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++i)
-        //     {
-        //         CHECK_EQ(ta[i].value(), to_value_type<T>(i + 1));
-        //     }
-        //     CHECK_FALSE(ta[ta.size() - 1].has_value());
-        // }
+        SUBCASE("operator[]")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+            typed_array<T> ta{array_data};
+            for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++i)
+            {
+                CHECK_EQ(ta[i].value(), to_value_type<T>(i + 1));
+            }
+            CHECK_FALSE(ta[ta.size() - 1].has_value());
+        }
 
-        // SUBCASE("const operator[]")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-        //     const typed_array<T> ta{array_data};
-        //     for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++i)
-        //     {
-        //         CHECK_EQ(ta[i].value(), to_value_type<T>(i + array_offset));
-        //     }
-        //     CHECK_FALSE(ta[false_bitmap[0] - array_offset].has_value());
-        // }
+        SUBCASE("const operator[]")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+            const typed_array<T> ta{array_data};
+            for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++i)
+            {
+                CHECK_EQ(ta[i].value(), to_value_type<T>(i + array_offset));
+            }
+            CHECK_FALSE(ta[false_bitmap[0] - array_offset].has_value());
+        }
 
-        // SUBCASE("front")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-        //     typed_array<T> ta{array_data};
-        //     CHECK_EQ(ta.front().value(), to_value_type<T>(1));
-        // }
+        SUBCASE("front")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+            typed_array<T> ta{array_data};
+            CHECK_EQ(ta.front().value(), to_value_type<T>(1));
+        }
 
-        // SUBCASE("const front")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-        //     const typed_array<T> ta{array_data};
-        //     CHECK_EQ(ta.front().value(), to_value_type<T>(1));
-        // }
+        SUBCASE("const front")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+            const typed_array<T> ta{array_data};
+            CHECK_EQ(ta.front().value(), to_value_type<T>(1));
+        }
 
-        // SUBCASE("back")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-        //     typed_array<T> ta{array_data};
-        //     CHECK_FALSE(ta.back().has_value());
-        // }
+        SUBCASE("back")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+            typed_array<T> ta{array_data};
+            CHECK_FALSE(ta.back().has_value());
+        }
 
-        // SUBCASE("const back")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-        //     const typed_array<T> ta{array_data};
-        //     CHECK_FALSE(ta.back().has_value());
-        // }
+        SUBCASE("const back")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+            const typed_array<T> ta{array_data};
+            CHECK_FALSE(ta.back().has_value());
+        }
 
-        // // Iterators
+        // Iterators
 
-        // SUBCASE("const iterators")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-        //     const typed_array<T> ta{array_data};
+        SUBCASE("const iterators")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+            const typed_array<T> ta{array_data};
 
-        //     auto iter = ta.cbegin();
-        //     CHECK(std::is_const_v<typename std::remove_reference_t<decltype(iter->value())>>);
-        //     auto iter_bis = ta.begin();
-        //     CHECK(std::is_const_v<typename std::remove_reference_t<decltype(iter_bis->value())>>);
-        //     CHECK_EQ(iter, iter_bis);
+            auto iter = ta.cbegin();
+            CHECK(std::is_const_v<typename std::remove_reference_t<decltype(iter->value())>>);
+            auto iter_bis = ta.begin();
+            CHECK(std::is_const_v<typename std::remove_reference_t<decltype(iter_bis->value())>>);
+            CHECK_EQ(iter, iter_bis);
 
-        //     const auto end = ta.cend();
-        //     CHECK(std::is_const_v<typename std::remove_reference_t<decltype(end->value())>>);
-        //     const auto end_bis = ta.end();
-        //     CHECK(std::is_const_v<typename std::remove_reference_t<decltype(end_bis->value())>>);
-        //     CHECK_EQ(end, end_bis);
+            const auto end = ta.cend();
+            CHECK(std::is_const_v<typename std::remove_reference_t<decltype(end->value())>>);
+            const auto end_bis = ta.end();
+            CHECK(std::is_const_v<typename std::remove_reference_t<decltype(end_bis->value())>>);
+            CHECK_EQ(end, end_bis);
 
-        //     for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++iter, ++i)
-        //     {
-        //         REQUIRE(iter->has_value());
-        //         CHECK_EQ(*iter, make_nullable(ta[i].value()));
-        //     }
+            for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++iter, ++i)
+            {
+                REQUIRE(iter->has_value());
+                CHECK_EQ(*iter, make_nullable(ta[i].value()));
+            }
 
-        //     CHECK_EQ(++iter, end);
+            CHECK_EQ(++iter, end);
 
-        //     const auto array_data_empty = sparrow::test::make_test_array_data<T>(0, 0);
-        //     const typed_array<T> typed_array_empty(array_data_empty);
-        //     CHECK_EQ(typed_array_empty.cbegin(), typed_array_empty.cend());
-        // }
+            const auto array_data_empty = sparrow::test::make_test_array_data<T>(0, 0);
+            const typed_array<T> typed_array_empty(array_data_empty);
+            CHECK_EQ(typed_array_empty.cbegin(), typed_array_empty.cend());
+        }
 
-        // SUBCASE("bitmap")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-        //     const typed_array<T> ta{array_data};
-        //     const auto bitmap = ta.bitmap();
-        //     REQUIRE_EQ(bitmap.size(), array_size - array_offset);
-        //     for (int32_t i = 0; i < static_cast<int32_t>(bitmap.size()) - 1; ++i)
-        //     {
-        //         CHECK(bitmap[i]);
-        //     }
-        //     CHECK_FALSE(bitmap[8]);
-        // }
+        SUBCASE("bitmap")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+            const typed_array<T> ta{array_data};
+            const auto bitmap = ta.bitmap();
+            REQUIRE_EQ(bitmap.size(), array_size - array_offset);
+            for (int32_t i = 0; i < static_cast<int32_t>(bitmap.size()) - 1; ++i)
+            {
+                CHECK(bitmap[i]);
+            }
+            CHECK_FALSE(bitmap[8]);
+        }
 
-        // SUBCASE("values")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-        //     const typed_array<T> ta{array_data};
-        //     const auto values = ta.values();
-        //     CHECK_EQ(values.size(), array_size - array_offset);
-        //     for (int32_t i = 0; i < static_cast<int32_t>(values.size()); ++i)
-        //     {
-        //         CHECK_EQ(values[i], to_value_type<T>(i + 1));
-        //     }
-        // }
+        SUBCASE("values")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+            const typed_array<T> ta{array_data};
+            const auto values = ta.values();
+            CHECK_EQ(values.size(), array_size - array_offset);
+            for (int32_t i = 0; i < static_cast<int32_t>(values.size()); ++i)
+            {
+                CHECK_EQ(values[i], to_value_type<T>(i + 1));
+            }
+        }
 
-        // // Capacity
+        // Capacity
 
-        // SUBCASE("empty")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-        //     const typed_array<T> ta{array_data};
-        //     CHECK_FALSE(ta.empty());
+        SUBCASE("empty")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+            const typed_array<T> ta{array_data};
+            CHECK_FALSE(ta.empty());
 
-        //     const auto array_data_empty = sparrow::test::make_test_array_data<T>(0, 0);
-        //     const typed_array<T> typed_array_empty(array_data_empty);
-        //     CHECK(typed_array_empty.empty());
-        // }
+            const auto array_data_empty = sparrow::test::make_test_array_data<T>(0, 0);
+            const typed_array<T> typed_array_empty(array_data_empty);
+            CHECK(typed_array_empty.empty());
+        }
 
-        // SUBCASE("size")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-        //     const typed_array<T> ta{array_data};
-        //     CHECK_EQ(ta.size(), array_size - array_offset);
-        // }
+        SUBCASE("size")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+            const typed_array<T> ta{array_data};
+            CHECK_EQ(ta.size(), array_size - array_offset);
+        }
 
-        // // Operators
+        // Operators
 
-        // SUBCASE("<=>")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-        //     const typed_array<T> ta{array_data};
-        //     CHECK_EQ(ta <=> ta, std::strong_ordering::equal);
+        SUBCASE("<=>")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+            const typed_array<T> ta{array_data};
+            CHECK_EQ(ta <=> ta, std::strong_ordering::equal);
 
-        //     const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
-        //     const typed_array<T> typed_array_less(array_data_less);
-        //     CHECK_EQ(ta <=> typed_array_less, std::strong_ordering::greater);
-        //     CHECK_EQ(typed_array_less <=> ta, std::strong_ordering::less);
-        // }
+            const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
+            const typed_array<T> typed_array_less(array_data_less);
+            CHECK_EQ(ta <=> typed_array_less, std::strong_ordering::greater);
+            CHECK_EQ(typed_array_less <=> ta, std::strong_ordering::less);
+        }
 
-        // SUBCASE("==")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-        //     const typed_array<T> ta{array_data};
-        //     const typed_array<T> ta_same{array_data};
-        //     CHECK(ta == ta);
-        //     CHECK(ta == ta_same);
+        SUBCASE("==")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+            const typed_array<T> ta{array_data};
+            const typed_array<T> ta_same{array_data};
+            CHECK(ta == ta);
+            CHECK(ta == ta_same);
 
-        //     const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
-        //     const ::typed_array<T> ta_less{array_data_less};
-        //     CHECK_FALSE(ta == ta_less);
-        //     CHECK_FALSE(ta_less == ta);
-        // }
+            const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
+            const ::typed_array<T> ta_less{array_data_less};
+            CHECK_FALSE(ta == ta_less);
+            CHECK_FALSE(ta_less == ta);
+        }
 
-        // SUBCASE("!=")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-        //     const typed_array<T> ta{array_data};
-        //     const typed_array<T> ta_same{array_data};
-        //     CHECK_FALSE(ta != ta);
-        //     CHECK_FALSE(ta != ta_same);
+        SUBCASE("!=")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+            const typed_array<T> ta{array_data};
+            const typed_array<T> ta_same{array_data};
+            CHECK_FALSE(ta != ta);
+            CHECK_FALSE(ta != ta_same);
 
-        //     const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
-        //     const typed_array<T> ta_less{array_data_less};
-        //     CHECK(ta != ta_less);
-        //     CHECK(ta_less != ta);
-        // }
+            const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
+            const typed_array<T> ta_less{array_data_less};
+            CHECK(ta != ta_less);
+            CHECK(ta_less != ta);
+        }
 
-        // SUBCASE("<")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-        //     const typed_array<T> ta{array_data};
-        //     const typed_array<T> ta_same{array_data};
-        //     CHECK_FALSE(ta < ta);
-        //     CHECK_FALSE(ta < ta_same);
+        SUBCASE("<")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+            const typed_array<T> ta{array_data};
+            const typed_array<T> ta_same{array_data};
+            CHECK_FALSE(ta < ta);
+            CHECK_FALSE(ta < ta_same);
 
-        //     const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
-        //     const typed_array<T> ta_less{array_data_less};
-        //     CHECK_FALSE(ta < ta_less);
-        //     CHECK(ta_less < ta);
-        // }
+            const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
+            const typed_array<T> ta_less{array_data_less};
+            CHECK_FALSE(ta < ta_less);
+            CHECK(ta_less < ta);
+        }
 
-        // SUBCASE(">")
-        // {
-        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-        //     const typed_array<T> ta{array_data};
-        //     const typed_array<T> ta_same{array_data};
-        //     CHECK_FALSE(ta > ta);
-        //     CHECK_FALSE(ta > ta_same);
+        SUBCASE(">")
+        {
+            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+            const typed_array<T> ta{array_data};
+            const typed_array<T> ta_same{array_data};
+            CHECK_FALSE(ta > ta);
+            CHECK_FALSE(ta > ta_same);
 
-        //     const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
-        //     const ::typed_array<T> ta_less{array_data_less};
-        //     CHECK(ta > ta_less);
-        //     CHECK_FALSE(ta_less > ta);
-        // }
+            const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
+            const ::typed_array<T> ta_less{array_data_less};
+            CHECK(ta > ta_less);
+            CHECK_FALSE(ta_less > ta);
+        }
     }
 
     TEST_CASE_TEMPLATE_DEFINE("all_except_string",  T, all_except_string)
@@ -505,35 +505,35 @@ TEST_SUITE("typed_array")
 
     TEST_CASE_TEMPLATE_INVOKE(
         all,
-        bool//,
-        // std::uint8_t,
-        // std::int8_t,
-        // std::uint16_t,
-        // std::int16_t,
-        // std::uint32_t,
-        // std::int32_t,
-        // std::uint64_t,
-        // std::int64_t,
-        // //std::string,
-        // float16_t,
-        // float32_t,
-        // float64_t
+        bool,
+        std::uint8_t,
+        std::int8_t,
+        std::uint16_t,
+        std::int16_t,
+        std::uint32_t,
+        std::int32_t,
+        std::uint64_t,
+        std::int64_t,
+        //std::string,
+        float16_t,
+        float32_t,
+        float64_t
     );
 
     TEST_CASE_TEMPLATE_INVOKE(
         all_except_string,
-        bool//,
-        // std::uint8_t,
-        // std::int8_t,
-        // std::uint16_t,
-        // std::int16_t,
-        // std::uint32_t,
-        // std::int32_t,
-        // std::uint64_t,
-        // std::int64_t,
-        // float16_t,
-        // float32_t,
-        // float64_t
+        bool,
+        std::uint8_t,
+        std::int8_t,
+        std::uint16_t,
+        std::int16_t,
+        std::uint32_t,
+        std::int32_t,
+        std::uint64_t,
+        std::int64_t,
+        float16_t,
+        float32_t,
+        float64_t
     );
 
 }

--- a/test/test_typed_array.cpp
+++ b/test/test_typed_array.cpp
@@ -505,38 +505,35 @@ TEST_SUITE("typed_array")
 
     TEST_CASE_TEMPLATE_INVOKE(
         all,
-        bool
-        //,
-        // std::uint8_t,
-        // std::int8_t,
-        // std::uint16_t,
-        // std::int16_t,
-        // std::uint32_t,
-        // std::int32_t,
-        // std::uint64_t,
-        // std::int64_t,
-        // std::string,
-        // float16_t,
-        // float32_t,
-        // float64_t
+        bool,
+        std::uint8_t,
+        std::int8_t,
+        std::uint16_t,
+        std::int16_t,
+        std::uint32_t,
+        std::int32_t,
+        std::uint64_t,
+        std::int64_t,
+        std::string,
+        float16_t,
+        float32_t,
+        float64_t
     );
 
     TEST_CASE_TEMPLATE_INVOKE(
         all_except_string,
-        bool
-        //,
-        //,
-        // std::uint8_t,
-        // std::int8_t,
-        // std::uint16_t,
-        // std::int16_t,
-        // std::uint32_t,
-        // std::int32_t,
-        // std::uint64_t,
-        // std::int64_t,
-        // float16_t,
-        // float32_t,
-        // float64_t
+        bool,
+        std::uint8_t,
+        std::int8_t,
+        std::uint16_t,
+        std::int16_t,
+        std::uint32_t,
+        std::int32_t,
+        std::uint64_t,
+        std::int64_t,
+        float16_t,
+        float32_t,
+        float64_t
     );
 
 }

--- a/test/test_typed_array.cpp
+++ b/test/test_typed_array.cpp
@@ -505,35 +505,38 @@ TEST_SUITE("typed_array")
 
     TEST_CASE_TEMPLATE_INVOKE(
         all,
-        bool,
-        std::uint8_t,
-        std::int8_t,
-        std::uint16_t,
-        std::int16_t,
-        std::uint32_t,
-        std::int32_t,
-        std::uint64_t,
-        std::int64_t,
-        std::string,
-        float16_t,
-        float32_t,
-        float64_t
+        bool
+        //,
+        // std::uint8_t,
+        // std::int8_t,
+        // std::uint16_t,
+        // std::int16_t,
+        // std::uint32_t,
+        // std::int32_t,
+        // std::uint64_t,
+        // std::int64_t,
+        // std::string,
+        // float16_t,
+        // float32_t,
+        // float64_t
     );
 
     TEST_CASE_TEMPLATE_INVOKE(
         all_except_string,
-        bool,
-        std::uint8_t,
-        std::int8_t,
-        std::uint16_t,
-        std::int16_t,
-        std::uint32_t,
-        std::int32_t,
-        std::uint64_t,
-        std::int64_t,
-        float16_t,
-        float32_t,
-        float64_t
+        bool
+        //,
+        //,
+        // std::uint8_t,
+        // std::int8_t,
+        // std::uint16_t,
+        // std::int16_t,
+        // std::uint32_t,
+        // std::int32_t,
+        // std::uint64_t,
+        // std::int64_t,
+        // float16_t,
+        // float32_t,
+        // float64_t
     );
 
 }

--- a/test/test_typed_array.cpp
+++ b/test/test_typed_array.cpp
@@ -30,9 +30,9 @@ using sparrow::test::to_value_type;
 
 namespace
 {
-    constexpr size_t array_size = 10;
-    constexpr size_t array_offset = 1;
-    const std::vector<size_t> false_bitmap = {9};
+    // constexpr size_t array_size = 10;
+    // constexpr size_t array_offset = 1;
+    // const std::vector<size_t> false_bitmap = {9};
 }
 
 namespace
@@ -53,20 +53,20 @@ namespace
 
 TEST_SUITE("typed_array")
 {
-    TEST_CASE("default constructor for variable_size_binary_layout")
-    {
-        using Layout = variable_size_binary_layout<std::string, const std::string_view>;
-        const typed_array<std::string, Layout> ta_for_vsbl;
-        CHECK_EQ(ta_for_vsbl.size(), 0);
-    }
+    // TEST_CASE("default constructor for variable_size_binary_layout")
+    // {
+    //     using Layout = variable_size_binary_layout<std::string, const std::string_view>;
+    //     const typed_array<std::string, Layout> ta_for_vsbl;
+    //     CHECK_EQ(ta_for_vsbl.size(), 0);
+    // }
 
-    TEST_CASE("default constructor for dictionary_encoded_layout")
-    {
-        using SubLayout = variable_size_binary_layout<std::string, const std::string_view>;
-        using Layout = dictionary_encoded_layout<std::uint32_t, SubLayout>;
-        typed_array<uint32_t, Layout> ta_for_dels;
-        CHECK_EQ(ta_for_dels.size(), 0);
-    }
+    // TEST_CASE("default constructor for dictionary_encoded_layout")
+    // {
+    //     using SubLayout = variable_size_binary_layout<std::string, const std::string_view>;
+    //     using Layout = dictionary_encoded_layout<std::uint32_t, SubLayout>;
+    //     typed_array<uint32_t, Layout> ta_for_dels;
+    //     CHECK_EQ(ta_for_dels.size(), 0);
+    // }
 
     /*TEST_CASE("constructor from range of nullable fixed_size_layout"){
         using nt = nullable<int32_t>;
@@ -185,39 +185,39 @@ TEST_SUITE("typed_array")
 
     TEST_CASE_TEMPLATE_DEFINE("all", T, all)
     {
-        SUBCASE("default constructor for fixed_size_layout")
-        {
-            using Layout = fixed_size_layout<int32_t>;
-            const typed_array<int32_t, Layout> ta_for_fsl;
-            CHECK_EQ(ta_for_fsl.size(), 0);
-        }
+        // SUBCASE("default constructor for fixed_size_layout")
+        // {
+        //     using Layout = fixed_size_layout<int32_t>;
+        //     const typed_array<int32_t, Layout> ta_for_fsl;
+        //     CHECK_EQ(ta_for_fsl.size(), 0);
+        // }
 
-        SUBCASE("constructor with parameter")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
-            const typed_array<T> ta{array_data};
-            CHECK_EQ(ta.size(), array_size - array_offset);
-        }
+        // SUBCASE("constructor with parameter")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
+        //     const typed_array<T> ta{array_data};
+        //     CHECK_EQ(ta.size(), array_size - array_offset);
+        // }
 
-        SUBCASE("copy constructor")
-        {
-            auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
-            typed_array<T> ta1{array_data};
-            typed_array<T> ta2(ta1);
+        // SUBCASE("copy constructor")
+        // {
+        //     auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
+        //     typed_array<T> ta1{array_data};
+        //     typed_array<T> ta2(ta1);
 
-            CHECK_EQ(ta1, ta2);
-        }
+        //     CHECK_EQ(ta1, ta2);
+        // }
 
-        SUBCASE("move constructor")
-        {
-            auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
-            typed_array<T> ta1{array_data};
-            typed_array<T> ta2(ta1);
-            typed_array<T> ta3(std::move(ta2));
+        // SUBCASE("move constructor")
+        // {
+        //     auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
+        //     typed_array<T> ta1{array_data};
+        //     typed_array<T> ta2(ta1);
+        //     typed_array<T> ta3(std::move(ta2));
 
-            CHECK_EQ(ta1, ta3);
-        }
-        /*SUBCASE("construct from range")
+        //     CHECK_EQ(ta1, ta3);
+        // }
+        SUBCASE("construct from range")
         {
             auto data = test::iota_vector<T>(10);
             typed_array<T> ta{data};
@@ -226,260 +226,260 @@ TEST_SUITE("typed_array")
             {
                 CHECK_EQ(ta[i].value(), data[i]);
             }
-        }*/
-        SUBCASE("copy assignment")
-        {
-            auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
-            typed_array<T> ta1{array_data};
-
-            auto array_data2 = sparrow::test::make_test_array_data<T>(array_size + 8u, array_offset);
-            typed_array<T> ta2{array_data2};
-
-            CHECK_NE(ta1, ta2);
-
-            ta2 = ta1;
-            CHECK_EQ(ta1, ta2);
         }
+        // SUBCASE("copy assignment")
+        // {
+        //     auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
+        //     typed_array<T> ta1{array_data};
 
-        SUBCASE("move assignment")
-        {
-            auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
-            typed_array<T> ta1{array_data};
-            typed_array<T> ta3{ta1};
+        //     auto array_data2 = sparrow::test::make_test_array_data<T>(array_size + 8u, array_offset);
+        //     typed_array<T> ta2{array_data2};
 
-            auto array_data2 = sparrow::test::make_test_array_data<T>(array_size + 8u, array_offset);
-            typed_array<T> ta2{array_data2};
+        //     CHECK_NE(ta1, ta2);
 
-            CHECK_NE(ta1, ta2);
+        //     ta2 = ta1;
+        //     CHECK_EQ(ta1, ta2);
+        // }
 
-            ta2 = std::move(ta1);
-            CHECK_EQ(ta3, ta2);
-        }
+        // SUBCASE("move assignment")
+        // {
+        //     auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
+        //     typed_array<T> ta1{array_data};
+        //     typed_array<T> ta3{ta1};
 
-        // Element access
+        //     auto array_data2 = sparrow::test::make_test_array_data<T>(array_size + 8u, array_offset);
+        //     typed_array<T> ta2{array_data2};
 
-        SUBCASE("at")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-            typed_array<T> ta{array_data};
-            for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++i)
-            {
-                CHECK_EQ(ta.at(i).value(), to_value_type<T>(i + array_offset));
-            }
-            CHECK_FALSE(ta.at(false_bitmap[0] - array_offset).has_value());
+        //     CHECK_NE(ta1, ta2);
 
-            CHECK_THROWS_AS(ta.at(ta.size()), std::out_of_range);
-        }
+        //     ta2 = std::move(ta1);
+        //     CHECK_EQ(ta3, ta2);
+        // }
 
-        SUBCASE("const at")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-            const typed_array<T> ta{array_data};
-            for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++i)
-            {
-                CHECK_EQ(ta.at(i).value(), to_value_type<T>(i + array_offset));
-            }
-            CHECK_FALSE(ta.at(false_bitmap[0] - array_offset).has_value());
+        // // Element access
 
-            CHECK_THROWS_AS(ta.at(ta.size()), std::out_of_range);
-        }
+        // SUBCASE("at")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+        //     typed_array<T> ta{array_data};
+        //     for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++i)
+        //     {
+        //         CHECK_EQ(ta.at(i).value(), to_value_type<T>(i + array_offset));
+        //     }
+        //     CHECK_FALSE(ta.at(false_bitmap[0] - array_offset).has_value());
 
-        SUBCASE("operator[]")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-            typed_array<T> ta{array_data};
-            for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++i)
-            {
-                CHECK_EQ(ta[i].value(), to_value_type<T>(i + 1));
-            }
-            CHECK_FALSE(ta[ta.size() - 1].has_value());
-        }
+        //     CHECK_THROWS_AS(ta.at(ta.size()), std::out_of_range);
+        // }
 
-        SUBCASE("const operator[]")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-            const typed_array<T> ta{array_data};
-            for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++i)
-            {
-                CHECK_EQ(ta[i].value(), to_value_type<T>(i + array_offset));
-            }
-            CHECK_FALSE(ta[false_bitmap[0] - array_offset].has_value());
-        }
+        // SUBCASE("const at")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+        //     const typed_array<T> ta{array_data};
+        //     for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++i)
+        //     {
+        //         CHECK_EQ(ta.at(i).value(), to_value_type<T>(i + array_offset));
+        //     }
+        //     CHECK_FALSE(ta.at(false_bitmap[0] - array_offset).has_value());
 
-        SUBCASE("front")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-            typed_array<T> ta{array_data};
-            CHECK_EQ(ta.front().value(), to_value_type<T>(1));
-        }
+        //     CHECK_THROWS_AS(ta.at(ta.size()), std::out_of_range);
+        // }
 
-        SUBCASE("const front")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-            const typed_array<T> ta{array_data};
-            CHECK_EQ(ta.front().value(), to_value_type<T>(1));
-        }
+        // SUBCASE("operator[]")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+        //     typed_array<T> ta{array_data};
+        //     for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++i)
+        //     {
+        //         CHECK_EQ(ta[i].value(), to_value_type<T>(i + 1));
+        //     }
+        //     CHECK_FALSE(ta[ta.size() - 1].has_value());
+        // }
 
-        SUBCASE("back")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-            typed_array<T> ta{array_data};
-            CHECK_FALSE(ta.back().has_value());
-        }
+        // SUBCASE("const operator[]")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+        //     const typed_array<T> ta{array_data};
+        //     for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++i)
+        //     {
+        //         CHECK_EQ(ta[i].value(), to_value_type<T>(i + array_offset));
+        //     }
+        //     CHECK_FALSE(ta[false_bitmap[0] - array_offset].has_value());
+        // }
 
-        SUBCASE("const back")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-            const typed_array<T> ta{array_data};
-            CHECK_FALSE(ta.back().has_value());
-        }
+        // SUBCASE("front")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+        //     typed_array<T> ta{array_data};
+        //     CHECK_EQ(ta.front().value(), to_value_type<T>(1));
+        // }
 
-        // Iterators
+        // SUBCASE("const front")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+        //     const typed_array<T> ta{array_data};
+        //     CHECK_EQ(ta.front().value(), to_value_type<T>(1));
+        // }
 
-        SUBCASE("const iterators")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-            const typed_array<T> ta{array_data};
+        // SUBCASE("back")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+        //     typed_array<T> ta{array_data};
+        //     CHECK_FALSE(ta.back().has_value());
+        // }
 
-            auto iter = ta.cbegin();
-            CHECK(std::is_const_v<typename std::remove_reference_t<decltype(iter->value())>>);
-            auto iter_bis = ta.begin();
-            CHECK(std::is_const_v<typename std::remove_reference_t<decltype(iter_bis->value())>>);
-            CHECK_EQ(iter, iter_bis);
+        // SUBCASE("const back")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+        //     const typed_array<T> ta{array_data};
+        //     CHECK_FALSE(ta.back().has_value());
+        // }
 
-            const auto end = ta.cend();
-            CHECK(std::is_const_v<typename std::remove_reference_t<decltype(end->value())>>);
-            const auto end_bis = ta.end();
-            CHECK(std::is_const_v<typename std::remove_reference_t<decltype(end_bis->value())>>);
-            CHECK_EQ(end, end_bis);
+        // // Iterators
 
-            for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++iter, ++i)
-            {
-                REQUIRE(iter->has_value());
-                CHECK_EQ(*iter, make_nullable(ta[i].value()));
-            }
+        // SUBCASE("const iterators")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+        //     const typed_array<T> ta{array_data};
 
-            CHECK_EQ(++iter, end);
+        //     auto iter = ta.cbegin();
+        //     CHECK(std::is_const_v<typename std::remove_reference_t<decltype(iter->value())>>);
+        //     auto iter_bis = ta.begin();
+        //     CHECK(std::is_const_v<typename std::remove_reference_t<decltype(iter_bis->value())>>);
+        //     CHECK_EQ(iter, iter_bis);
 
-            const auto array_data_empty = sparrow::test::make_test_array_data<T>(0, 0);
-            const typed_array<T> typed_array_empty(array_data_empty);
-            CHECK_EQ(typed_array_empty.cbegin(), typed_array_empty.cend());
-        }
+        //     const auto end = ta.cend();
+        //     CHECK(std::is_const_v<typename std::remove_reference_t<decltype(end->value())>>);
+        //     const auto end_bis = ta.end();
+        //     CHECK(std::is_const_v<typename std::remove_reference_t<decltype(end_bis->value())>>);
+        //     CHECK_EQ(end, end_bis);
 
-        SUBCASE("bitmap")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-            const typed_array<T> ta{array_data};
-            const auto bitmap = ta.bitmap();
-            REQUIRE_EQ(bitmap.size(), array_size - array_offset);
-            for (int32_t i = 0; i < static_cast<int32_t>(bitmap.size()) - 1; ++i)
-            {
-                CHECK(bitmap[i]);
-            }
-            CHECK_FALSE(bitmap[8]);
-        }
+        //     for (typename typed_array<T>::size_type i = 0; i < ta.size() - 1; ++iter, ++i)
+        //     {
+        //         REQUIRE(iter->has_value());
+        //         CHECK_EQ(*iter, make_nullable(ta[i].value()));
+        //     }
 
-        SUBCASE("values")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-            const typed_array<T> ta{array_data};
-            const auto values = ta.values();
-            CHECK_EQ(values.size(), array_size - array_offset);
-            for (int32_t i = 0; i < static_cast<int32_t>(values.size()); ++i)
-            {
-                CHECK_EQ(values[i], to_value_type<T>(i + 1));
-            }
-        }
+        //     CHECK_EQ(++iter, end);
 
-        // Capacity
+        //     const auto array_data_empty = sparrow::test::make_test_array_data<T>(0, 0);
+        //     const typed_array<T> typed_array_empty(array_data_empty);
+        //     CHECK_EQ(typed_array_empty.cbegin(), typed_array_empty.cend());
+        // }
 
-        SUBCASE("empty")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-            const typed_array<T> ta{array_data};
-            CHECK_FALSE(ta.empty());
+        // SUBCASE("bitmap")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+        //     const typed_array<T> ta{array_data};
+        //     const auto bitmap = ta.bitmap();
+        //     REQUIRE_EQ(bitmap.size(), array_size - array_offset);
+        //     for (int32_t i = 0; i < static_cast<int32_t>(bitmap.size()) - 1; ++i)
+        //     {
+        //         CHECK(bitmap[i]);
+        //     }
+        //     CHECK_FALSE(bitmap[8]);
+        // }
 
-            const auto array_data_empty = sparrow::test::make_test_array_data<T>(0, 0);
-            const typed_array<T> typed_array_empty(array_data_empty);
-            CHECK(typed_array_empty.empty());
-        }
+        // SUBCASE("values")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+        //     const typed_array<T> ta{array_data};
+        //     const auto values = ta.values();
+        //     CHECK_EQ(values.size(), array_size - array_offset);
+        //     for (int32_t i = 0; i < static_cast<int32_t>(values.size()); ++i)
+        //     {
+        //         CHECK_EQ(values[i], to_value_type<T>(i + 1));
+        //     }
+        // }
 
-        SUBCASE("size")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-            const typed_array<T> ta{array_data};
-            CHECK_EQ(ta.size(), array_size - array_offset);
-        }
+        // // Capacity
 
-        // Operators
+        // SUBCASE("empty")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+        //     const typed_array<T> ta{array_data};
+        //     CHECK_FALSE(ta.empty());
 
-        SUBCASE("<=>")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-            const typed_array<T> ta{array_data};
-            CHECK_EQ(ta <=> ta, std::strong_ordering::equal);
+        //     const auto array_data_empty = sparrow::test::make_test_array_data<T>(0, 0);
+        //     const typed_array<T> typed_array_empty(array_data_empty);
+        //     CHECK(typed_array_empty.empty());
+        // }
 
-            const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
-            const typed_array<T> typed_array_less(array_data_less);
-            CHECK_EQ(ta <=> typed_array_less, std::strong_ordering::greater);
-            CHECK_EQ(typed_array_less <=> ta, std::strong_ordering::less);
-        }
+        // SUBCASE("size")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+        //     const typed_array<T> ta{array_data};
+        //     CHECK_EQ(ta.size(), array_size - array_offset);
+        // }
 
-        SUBCASE("==")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-            const typed_array<T> ta{array_data};
-            const typed_array<T> ta_same{array_data};
-            CHECK(ta == ta);
-            CHECK(ta == ta_same);
+        // // Operators
 
-            const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
-            const ::typed_array<T> ta_less{array_data_less};
-            CHECK_FALSE(ta == ta_less);
-            CHECK_FALSE(ta_less == ta);
-        }
+        // SUBCASE("<=>")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+        //     const typed_array<T> ta{array_data};
+        //     CHECK_EQ(ta <=> ta, std::strong_ordering::equal);
 
-        SUBCASE("!=")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-            const typed_array<T> ta{array_data};
-            const typed_array<T> ta_same{array_data};
-            CHECK_FALSE(ta != ta);
-            CHECK_FALSE(ta != ta_same);
+        //     const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
+        //     const typed_array<T> typed_array_less(array_data_less);
+        //     CHECK_EQ(ta <=> typed_array_less, std::strong_ordering::greater);
+        //     CHECK_EQ(typed_array_less <=> ta, std::strong_ordering::less);
+        // }
 
-            const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
-            const typed_array<T> ta_less{array_data_less};
-            CHECK(ta != ta_less);
-            CHECK(ta_less != ta);
-        }
+        // SUBCASE("==")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+        //     const typed_array<T> ta{array_data};
+        //     const typed_array<T> ta_same{array_data};
+        //     CHECK(ta == ta);
+        //     CHECK(ta == ta_same);
 
-        SUBCASE("<")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-            const typed_array<T> ta{array_data};
-            const typed_array<T> ta_same{array_data};
-            CHECK_FALSE(ta < ta);
-            CHECK_FALSE(ta < ta_same);
+        //     const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
+        //     const ::typed_array<T> ta_less{array_data_less};
+        //     CHECK_FALSE(ta == ta_less);
+        //     CHECK_FALSE(ta_less == ta);
+        // }
 
-            const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
-            const typed_array<T> ta_less{array_data_less};
-            CHECK_FALSE(ta < ta_less);
-            CHECK(ta_less < ta);
-        }
+        // SUBCASE("!=")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+        //     const typed_array<T> ta{array_data};
+        //     const typed_array<T> ta_same{array_data};
+        //     CHECK_FALSE(ta != ta);
+        //     CHECK_FALSE(ta != ta_same);
 
-        SUBCASE(">")
-        {
-            const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
-            const typed_array<T> ta{array_data};
-            const typed_array<T> ta_same{array_data};
-            CHECK_FALSE(ta > ta);
-            CHECK_FALSE(ta > ta_same);
+        //     const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
+        //     const typed_array<T> ta_less{array_data_less};
+        //     CHECK(ta != ta_less);
+        //     CHECK(ta_less != ta);
+        // }
 
-            const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
-            const ::typed_array<T> ta_less{array_data_less};
-            CHECK(ta > ta_less);
-            CHECK_FALSE(ta_less > ta);
-        }
+        // SUBCASE("<")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+        //     const typed_array<T> ta{array_data};
+        //     const typed_array<T> ta_same{array_data};
+        //     CHECK_FALSE(ta < ta);
+        //     CHECK_FALSE(ta < ta_same);
+
+        //     const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
+        //     const typed_array<T> ta_less{array_data_less};
+        //     CHECK_FALSE(ta < ta_less);
+        //     CHECK(ta_less < ta);
+        // }
+
+        // SUBCASE(">")
+        // {
+        //     const auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset, false_bitmap);
+        //     const typed_array<T> ta{array_data};
+        //     const typed_array<T> ta_same{array_data};
+        //     CHECK_FALSE(ta > ta);
+        //     CHECK_FALSE(ta > ta_same);
+
+        //     const auto array_data_less = sparrow::test::make_test_array_data<T>(array_size - 1, array_offset - 1, {8});
+        //     const ::typed_array<T> ta_less{array_data_less};
+        //     CHECK(ta > ta_less);
+        //     CHECK_FALSE(ta_less > ta);
+        // }
     }
 
     TEST_CASE_TEMPLATE_DEFINE("all_except_string",  T, all_except_string)
@@ -487,53 +487,53 @@ TEST_SUITE("typed_array")
         // this constructor is not available for string on purpose
         // because std::string is auto mapped to a variable_size_binary_layout 
         // which defeats the purpose of this constructor
-        SUBCASE("constructor_with_n_inital_value")
-        {   
-            // get a "one" in a generic way with iota_vector of length 2 at index 1 =)
-            const auto data = test::iota_vector<T>(2);
-            const auto one = data[1];
+        // SUBCASE("constructor_with_n_inital_value")
+        // {   
+        //     // get a "one" in a generic way with iota_vector of length 2 at index 1 =)
+        //     const auto data = test::iota_vector<T>(2);
+        //     const auto one = data[1];
 
-            const typed_array<T> ta{10, one};
-            CHECK_EQ(ta.size(), 10);
+        //     const typed_array<T> ta{10, one};
+        //     CHECK_EQ(ta.size(), 10);
 
-            for (size_t i = 0; i < ta.size(); ++i)
-            {
-                CHECK_EQ(ta[i].value(), one);
-            }
-        }
+        //     for (size_t i = 0; i < ta.size(); ++i)
+        //     {
+        //         CHECK_EQ(ta[i].value(), one);
+        //     }
+        // }
     }
 
     TEST_CASE_TEMPLATE_INVOKE(
         all,
-        bool,
-        std::uint8_t,
-        std::int8_t,
-        std::uint16_t,
-        std::int16_t,
-        std::uint32_t,
-        std::int32_t,
-        std::uint64_t,
-        std::int64_t,
-        std::string,
-        float16_t,
-        float32_t,
-        float64_t
+        bool//,
+        // std::uint8_t,
+        // std::int8_t,
+        // std::uint16_t,
+        // std::int16_t,
+        // std::uint32_t,
+        // std::int32_t,
+        // std::uint64_t,
+        // std::int64_t,
+        // //std::string,
+        // float16_t,
+        // float32_t,
+        // float64_t
     );
 
     TEST_CASE_TEMPLATE_INVOKE(
         all_except_string,
-        bool,
-        std::uint8_t,
-        std::int8_t,
-        std::uint16_t,
-        std::int16_t,
-        std::uint32_t,
-        std::int32_t,
-        std::uint64_t,
-        std::int64_t,
-        float16_t,
-        float32_t,
-        float64_t
+        bool//,
+        // std::uint8_t,
+        // std::int8_t,
+        // std::uint16_t,
+        // std::int16_t,
+        // std::uint32_t,
+        // std::int32_t,
+        // std::uint64_t,
+        // std::int64_t,
+        // float16_t,
+        // float32_t,
+        // float64_t
     );
 
 }

--- a/test/test_typed_array.cpp
+++ b/test/test_typed_array.cpp
@@ -227,6 +227,20 @@ TEST_SUITE("typed_array")
                 CHECK_EQ(ta[i].value(), data[i]);
             }
         }
+        SUBCASE("constructor_with_n_inital_value")
+        {   
+            // get a "one" in a generic way with iota_vector of length 2 at index 1 =)
+            const auto data = test::iota_vector<T>(2);
+            T one = data[1];
+
+            const typed_array<T> ta{std::size_t(10), one};
+            CHECK_EQ(ta.size(), 10);
+
+            for (size_t i = 0; i < ta.size(); ++i)
+            {
+                CHECK_EQ(ta[i].value(), one);
+            }
+        }
         SUBCASE("copy assignment")
         {
             auto array_data = sparrow::test::make_test_array_data<T>(array_size, array_offset);
@@ -482,25 +496,6 @@ TEST_SUITE("typed_array")
         }
     }
 
-    TEST_CASE_TEMPLATE_DEFINE("all_except_string",  T, all_except_string)
-    {
-
-        SUBCASE("constructor_with_n_inital_value")
-        {   
-            // get a "one" in a generic way with iota_vector of length 2 at index 1 =)
-            const auto data = test::iota_vector<T>(2);
-            T one = data[1];
-
-            const typed_array<T> ta{std::size_t(10), one};
-            CHECK_EQ(ta.size(), 10);
-
-            for (size_t i = 0; i < ta.size(); ++i)
-            {
-                CHECK_EQ(ta[i].value(), one);
-            }
-        }
-    }
-
     TEST_CASE_TEMPLATE_INVOKE(
         all,
         bool,
@@ -512,23 +507,7 @@ TEST_SUITE("typed_array")
         std::int32_t,
         std::uint64_t,
         std::int64_t,
-        //std::string,
-        float16_t,
-        float32_t,
-        float64_t
-    );
-
-    TEST_CASE_TEMPLATE_INVOKE(
-        all_except_string,
-        bool,
-        std::uint8_t,
-        std::int8_t,
-        std::uint16_t,
-        std::int16_t,
-        std::uint32_t,
-        std::int32_t,
-        std::uint64_t,
-        std::int64_t,
+        std::string,
         float16_t,
         float32_t,
         float64_t


### PR DESCRIPTION
* use pre-existing factory functions
* use values for bitmaps instead of const reference
* remove requirement for const_range (does not work for std::vector<bool> because our concept check for const_ranges is not working for std::vector<bool> )
* added `is_mutable` to array_data / external_array_data

The constructor from ranges for ranges of nullables will be added in a followup PR