### PR TITLE
Buffer adaptor with immutable input

### DIFF
--- a/include/sparrow/buffer/buffer_adaptor.hpp
+++ b/include/sparrow/buffer/buffer_adaptor.hpp
@@ -14,12 +14,14 @@
 
 #pragma once
 
+#include <cmath>
 #include <ranges>
 #include <type_traits>
 
 #include "sparrow/utils/contracts.hpp"
 #include "sparrow/utils/iterator.hpp"
 #include "sparrow/utils/mp_utils.hpp"
+
 
 namespace sparrow
 {

--- a/include/sparrow/buffer/buffer_adaptor.hpp
+++ b/include/sparrow/buffer/buffer_adaptor.hpp
@@ -176,11 +176,11 @@ namespace sparrow
         {
             const difference_type index = std::distance(cbegin(), pos);
             const auto idx_for_buffer = index_for_buffer(static_cast<size_type>(index));
-            SPARROW_ASSERT_TRUE(idx_for_buffer <= m_buffer.get().size());
-            return std::next(m_buffer.get().cbegin(), static_cast<difference_type>(idx_for_buffer));
+            SPARROW_ASSERT_TRUE(idx_for_buffer <= m_buffer.size());
+            return std::next(m_buffer.cbegin(), static_cast<difference_type>(idx_for_buffer));
         }
 
-        std::reference_wrapper<std::remove_reference_t<buffer_reference>> m_buffer;
+        buffer_reference m_buffer;
         size_type m_max_size;
     };
 
@@ -189,7 +189,7 @@ namespace sparrow
     buffer_adaptor<To, FromBufferRef>::buffer_adaptor(FromBufferRef buf)
         requires(not is_const)
         : m_buffer(buf)
-        , m_max_size(m_buffer.get().max_size() / m_to_from_size_ratio)
+        , m_max_size(m_buffer.max_size() / m_to_from_size_ratio)
     {
     }
 
@@ -197,7 +197,7 @@ namespace sparrow
         requires T_is_const_if_FromBufferRef_is_const<FromBufferRef, To>
     buffer_adaptor<To, FromBufferRef>::buffer_adaptor(const FromBufferRef buf)
         : m_buffer(buf)
-        , m_max_size(m_buffer.get().max_size() / m_to_from_size_ratio)
+        , m_max_size(m_buffer.max_size() / m_to_from_size_ratio)
     {
     }
 
@@ -207,7 +207,7 @@ namespace sparrow
     buffer_adaptor<To, FromBufferRef>::data() noexcept
         requires(not is_const)
     {
-        return m_buffer.get().template data<value_type>();
+        return m_buffer.template data<value_type>();
     }
 
     template <typename To, BufferReference<To> FromBufferRef>
@@ -215,7 +215,7 @@ namespace sparrow
     constexpr typename buffer_adaptor<To, FromBufferRef>::const_pointer
     buffer_adaptor<To, FromBufferRef>::data() const noexcept
     {
-        return m_buffer.get().template data<value_type>();
+        return m_buffer.template data<value_type>();
     }
 
     template <typename To, BufferReference<To> FromBufferRef>
@@ -380,7 +380,7 @@ namespace sparrow
     constexpr buffer_adaptor<To, FromBufferRef>::size_type
     buffer_adaptor<To, FromBufferRef>::size() const noexcept
     {
-        const double new_size = static_cast<double>(m_buffer.get().size()) * m_from_to_size_ratio;
+        const double new_size = static_cast<double>(m_buffer.size()) * m_from_to_size_ratio;
         SPARROW_ASSERT(
             std::trunc(new_size) == new_size,
             "The size of the buffer is not a multiple of the size of the new type"
@@ -401,14 +401,14 @@ namespace sparrow
     constexpr typename buffer_adaptor<To, FromBufferRef>::size_type
     buffer_adaptor<To, FromBufferRef>::capacity() const noexcept
     {
-        return m_buffer.get().capacity() / m_to_from_size_ratio;
+        return m_buffer.capacity() / m_to_from_size_ratio;
     }
 
     template <typename To, BufferReference<To> FromBufferRef>
         requires T_is_const_if_FromBufferRef_is_const<FromBufferRef, To>
     constexpr bool buffer_adaptor<To, FromBufferRef>::empty() const noexcept
     {
-        return m_buffer.get().empty();
+        return m_buffer.empty();
     }
 
     template <typename To, BufferReference<To> FromBufferRef>
@@ -416,7 +416,7 @@ namespace sparrow
     constexpr void buffer_adaptor<To, FromBufferRef>::reserve(size_type new_cap)
         requires(not is_const)
     {
-        m_buffer.get().reserve(new_cap * m_to_from_size_ratio);
+        m_buffer.reserve(new_cap * m_to_from_size_ratio);
     }
 
     template <typename To, BufferReference<To> FromBufferRef>
@@ -424,7 +424,7 @@ namespace sparrow
     constexpr void buffer_adaptor<To, FromBufferRef>::shrink_to_fit()
         requires(not is_const)
     {
-        m_buffer.get().shrink_to_fit();
+        m_buffer.shrink_to_fit();
     }
 
     // Modifiers
@@ -434,7 +434,7 @@ namespace sparrow
     constexpr void buffer_adaptor<To, FromBufferRef>::clear() noexcept
         requires(not is_const)
     {
-        m_buffer.get().clear();
+        m_buffer.clear();
     }
 
     template <typename To, BufferReference<To> FromBufferRef>
@@ -447,7 +447,7 @@ namespace sparrow
         SPARROW_ASSERT_TRUE(pos <= cend());
         const difference_type index = std::distance(cbegin(), pos);
         const auto buffer_pos = get_buffer_reference_iterator(pos);
-        m_buffer.get().insert(buffer_pos, m_to_from_size_ratio, 0);
+        m_buffer.insert(buffer_pos, m_to_from_size_ratio, 0);
         operator[](static_cast<size_type>(index)) = value;
         return std::next(begin(), index);
     }
@@ -462,7 +462,7 @@ namespace sparrow
         SPARROW_ASSERT_TRUE(pos <= cend());
         const difference_type index = std::distance(cbegin(), pos);
         const auto buffer_pos = get_buffer_reference_iterator(pos);
-        m_buffer.get().insert(buffer_pos, count * m_to_from_size_ratio, 0);
+        m_buffer.insert(buffer_pos, count * m_to_from_size_ratio, 0);
         for (size_type i = 0; i < count; ++i)
         {
             data()[static_cast<size_t>(index) + i] = value;
@@ -483,7 +483,7 @@ namespace sparrow
         const difference_type index = std::distance(cbegin(), pos);
         const difference_type count = std::distance(first, last);
         const auto buffer_pos = get_buffer_reference_iterator(pos);
-        m_buffer.get().insert(buffer_pos, static_cast<size_type>(count) * m_to_from_size_ratio, 0);
+        m_buffer.insert(buffer_pos, static_cast<size_type>(count) * m_to_from_size_ratio, 0);
         std::copy(first, last, data() + index);
         return std::next(begin(), index);
     }
@@ -508,7 +508,7 @@ namespace sparrow
         SPARROW_ASSERT_TRUE(pos <= cend());
         const difference_type index = std::distance(cbegin(), pos);
         const auto buffer_pos = get_buffer_reference_iterator(pos);
-        m_buffer.get().insert(buffer_pos, m_to_from_size_ratio, 0);
+        m_buffer.insert(buffer_pos, m_to_from_size_ratio, 0);
         data()[index] = value_type(std::forward<Args>(args)...);
         return std::next(begin(), index);
     }
@@ -527,11 +527,11 @@ namespace sparrow
         }
         const difference_type index = std::distance(cbegin(), pos);
         const auto idx_for_buffer = index_for_buffer(static_cast<size_type>(index));
-        SPARROW_ASSERT_TRUE(idx_for_buffer < m_buffer.get().size());
+        SPARROW_ASSERT_TRUE(idx_for_buffer < m_buffer.size());
 
-        m_buffer.get().erase(
-            std::next(m_buffer.get().cbegin(), static_cast<difference_type>(idx_for_buffer)),
-            std::next(m_buffer.get().cbegin(), static_cast<difference_type>(idx_for_buffer + m_to_from_size_ratio))
+        m_buffer.erase(
+            std::next(m_buffer.cbegin(), static_cast<difference_type>(idx_for_buffer)),
+            std::next(m_buffer.cbegin(), static_cast<difference_type>(idx_for_buffer + m_to_from_size_ratio))
         );
         return std::next(begin(), index);
     }
@@ -551,12 +551,12 @@ namespace sparrow
         const difference_type index_first = std::distance(cbegin(), first);
         const difference_type index_last = std::distance(cbegin(), last);
         const auto idx_for_buffer_first = index_for_buffer(static_cast<size_type>(index_first));
-        SPARROW_ASSERT_TRUE(idx_for_buffer_first < m_buffer.get().size());
+        SPARROW_ASSERT_TRUE(idx_for_buffer_first < m_buffer.size());
         const auto idx_for_buffer_last = index_for_buffer(static_cast<size_type>(index_last));
-        SPARROW_ASSERT_TRUE(idx_for_buffer_last <= m_buffer.get().size());
-        m_buffer.get().erase(
-            std::next(m_buffer.get().cbegin(), static_cast<difference_type>(idx_for_buffer_first)),
-            std::next(m_buffer.get().cbegin(), static_cast<difference_type>(idx_for_buffer_last))
+        SPARROW_ASSERT_TRUE(idx_for_buffer_last <= m_buffer.size());
+        m_buffer.erase(
+            std::next(m_buffer.cbegin(), static_cast<difference_type>(idx_for_buffer_first)),
+            std::next(m_buffer.cbegin(), static_cast<difference_type>(idx_for_buffer_last))
         );
         return std::next(begin(), index_first);
     }
@@ -585,7 +585,7 @@ namespace sparrow
         const auto new_size_for_buffer = static_cast<size_type>(
             static_cast<double>(new_size) / m_from_to_size_ratio
         );
-        m_buffer.get().resize(new_size_for_buffer);
+        m_buffer.resize(new_size_for_buffer);
     }
 
     template <typename To, BufferReference<To> FromBufferRef>
@@ -597,7 +597,7 @@ namespace sparrow
         const auto new_size_for_buffer = static_cast<size_type>(
             static_cast<double>(new_size) / m_from_to_size_ratio
         );
-        m_buffer.get().resize(new_size_for_buffer, 0);
+        m_buffer.resize(new_size_for_buffer, 0);
         for (size_type i = original_size; i < new_size; ++i)
         {
             operator[](i) = value;

--- a/include/sparrow/utils/mp_utils.hpp
+++ b/include/sparrow/utils/mp_utils.hpp
@@ -473,7 +473,7 @@ namespace sparrow::mpl
     template <class T>
     concept testable = requires(T t) {  t ? true : false; };
 
-    // Failes if the Qualifier is true for Y but not for T.
+    // Fails if the Qualifier is true for Y but not for T.
     template <typename T, typename Y, template <typename> typename Qualifier>
     concept T_matches_qualifier_if_Y_is = Qualifier<T>::value || !Qualifier<Y>::value;
 }

--- a/include/sparrow/utils/mp_utils.hpp
+++ b/include/sparrow/utils/mp_utils.hpp
@@ -471,5 +471,9 @@ namespace sparrow::mpl
 
     // Matches any type that is testable
     template <class T>
-    concept testable = requires(T t) { t ? true : false; };
+    concept testable = requires(T t) {  t ? true : false; };
+
+    // Failes if the Qualifier is true for Y but not for T.
+    template <typename T, typename Y, template <typename> typename Qualifier>
+    concept T_matches_qualifier_if_Y_is = Qualifier<T>::value || !Qualifier<Y>::value;
 }

--- a/test/test_buffer_adaptor.cpp
+++ b/test/test_buffer_adaptor.cpp
@@ -14,6 +14,7 @@
 
 #include <array>
 #include <cstdint>
+#include <list>
 
 #include "sparrow/buffer/buffer.hpp"
 #include "sparrow/buffer/buffer_adaptor.hpp"

--- a/test/test_buffer_adaptor.cpp
+++ b/test/test_buffer_adaptor.cpp
@@ -120,6 +120,9 @@ namespace sparrow
                 buffer_adaptor<uint32_t, decltype(buf)&> buffer_adapt(buf);
                 CHECK_EQ(buffer_adapt[0], 0x04030201);
                 CHECK_EQ(buffer_adapt[1], 0x08070605);
+
+                buffer_adapt[0] = 0x11111111;
+                CHECK_EQ(buf[0], 0x11);
             }
 
             SUBCASE("from const data")
@@ -339,6 +342,7 @@ namespace sparrow
             buffer<uint8_t> buf(input);
             const buffer_adaptor<uint32_t, decltype(buf)&> buffer_adapt(buf);
             CHECK_EQ(buffer_adapt.size(), 2);
+            CHECK_EQ(buf.size(), 8);
         }
 
         TEST_CASE("empty")
@@ -346,10 +350,12 @@ namespace sparrow
             buffer<uint8_t> empty_buf;
             const buffer_adaptor<uint32_t, decltype(empty_buf)&> buffer_adapt(empty_buf);
             CHECK(buffer_adapt.empty());
+            CHECK(empty_buf.empty());
 
             buffer<uint8_t> buf2(input);
             const buffer_adaptor<uint32_t, decltype(buf2)&> buffer_adapt2(buf2);
-            CHECK(!buffer_adapt2.empty());
+            CHECK_FALSE(buffer_adapt2.empty());
+            CHECK_FALSE(buf2.empty());
         }
 
         TEST_CASE("capacity")
@@ -357,6 +363,7 @@ namespace sparrow
             buffer<uint8_t> buf(input);
             buffer_adaptor<uint32_t, decltype(buf)&> buffer_adapt(buf);
             CHECK_EQ(buffer_adapt.capacity(), 2);
+            CHECK_EQ(buf.capacity(), 8);
         }
 
         TEST_CASE("reserve")
@@ -365,6 +372,7 @@ namespace sparrow
             buffer_adaptor<uint32_t, decltype(buf)&> buffer_adapt(buf);
             buffer_adapt.reserve(10);
             CHECK_EQ(buffer_adapt.capacity(), 10);
+            CHECK_EQ(buf.capacity(), 40);
         }
 
         TEST_CASE("shrink_to_fit")
@@ -372,10 +380,13 @@ namespace sparrow
             buffer<uint8_t> buf(input);
             buffer_adaptor<uint32_t, decltype(buf)&> buffer_adapt(buf);
             CHECK_EQ(buffer_adapt.capacity(), 2);
+            CHECK_EQ(buf.capacity(), 8);
             buffer_adapt.reserve(50);
             CHECK_EQ(buffer_adapt.capacity(), 50);
+            CHECK_EQ(buf.capacity(), 200);
             buffer_adapt.shrink_to_fit();
             CHECK_EQ(buffer_adapt.capacity(), 2);
+            CHECK_EQ(buf.capacity(), 8);
         }
 
         // Modifiers
@@ -385,7 +396,8 @@ namespace sparrow
             buffer<uint8_t> buf(input);
             buffer_adaptor<uint32_t, decltype(buf)&> buffer_adapt(buf);
             buffer_adapt.clear();
-            CHECK_EQ(buffer_adapt.size(), 0);
+            CHECK(buffer_adapt.empty());
+            CHECK(buf.empty());
         }
 
         TEST_CASE("insert")
@@ -408,6 +420,7 @@ namespace sparrow
                     CHECK_EQ(buffer_adapt[0], to_insert);
                     CHECK_EQ(buffer_adapt[1], 0x04030201);
                     CHECK_EQ(buffer_adapt[2], 0x08070605);
+                    CHECK_EQ(buf.size(), 12);
                 }
 
                 SUBCASE("in the middle")
@@ -426,6 +439,7 @@ namespace sparrow
                     CHECK_EQ(buffer_adapt[0], 0x04030201);
                     CHECK_EQ(buffer_adapt[1], to_insert);
                     CHECK_EQ(buffer_adapt[2], 0x08070605);
+                    CHECK_EQ(buf.size(), 12);
                 }
 
                 SUBCASE("at the end")
@@ -444,6 +458,7 @@ namespace sparrow
                     CHECK_EQ(buffer_adapt[0], 0x04030201);
                     CHECK_EQ(buffer_adapt[1], 0x08070605);
                     CHECK_EQ(buffer_adapt[2], to_insert);
+                    CHECK_EQ(buf.size(), 12);
                 }
             }
 
@@ -467,6 +482,7 @@ namespace sparrow
                     CHECK_EQ(buffer_adapt[1], to_insert);
                     CHECK_EQ(buffer_adapt[2], 0x04030201);
                     CHECK_EQ(buffer_adapt[3], 0x08070605);
+                    CHECK_EQ(buf.size(), 16);
                 }
 
                 SUBCASE("in the middle")
@@ -487,6 +503,7 @@ namespace sparrow
                     CHECK_EQ(buffer_adapt[1], to_insert);
                     CHECK_EQ(buffer_adapt[2], to_insert);
                     CHECK_EQ(buffer_adapt[3], 0x08070605);
+                    CHECK_EQ(buf.size(), 16);
                 }
 
                 SUBCASE("at the end")
@@ -507,6 +524,7 @@ namespace sparrow
                     CHECK_EQ(buffer_adapt[1], 0x08070605);
                     CHECK_EQ(buffer_adapt[2], to_insert);
                     CHECK_EQ(buffer_adapt[3], to_insert);
+                    CHECK_EQ(buf.size(), 16);
                 }
             }
 
@@ -530,6 +548,7 @@ namespace sparrow
                     CHECK_EQ(buffer_adapt[1], to_insert[1]);
                     CHECK_EQ(buffer_adapt[2], 0x04030201);
                     CHECK_EQ(buffer_adapt[3], 0x08070605);
+                    CHECK_EQ(buf.size(), 16);
                 }
 
                 SUBCASE("in the middle")
@@ -550,6 +569,7 @@ namespace sparrow
                     CHECK_EQ(buffer_adapt[1], to_insert[0]);
                     CHECK_EQ(buffer_adapt[2], to_insert[1]);
                     CHECK_EQ(buffer_adapt[3], 0x08070605);
+                    CHECK_EQ(buf.size(), 16);
                 }
 
                 SUBCASE("at the end")
@@ -570,6 +590,7 @@ namespace sparrow
                     CHECK_EQ(buffer_adapt[1], 0x08070605);
                     CHECK_EQ(buffer_adapt[2], to_insert[0]);
                     CHECK_EQ(buffer_adapt[3], to_insert[1]);
+                    CHECK_EQ(buf.size(), 16);
                 }
             }
         }
@@ -592,6 +613,7 @@ namespace sparrow
                 CHECK_EQ(buffer_adapt[0], to_insert);
                 CHECK_EQ(buffer_adapt[1], 0x04030201);
                 CHECK_EQ(buffer_adapt[2], 0x08070605);
+                CHECK_EQ(buf.size(), 12);
             }
 
             SUBCASE("in the middle")
@@ -610,6 +632,7 @@ namespace sparrow
                 CHECK_EQ(buffer_adapt[0], 0x04030201);
                 CHECK_EQ(buffer_adapt[1], to_insert);
                 CHECK_EQ(buffer_adapt[2], 0x08070605);
+                CHECK_EQ(buf.size(), 12);
             }
 
             SUBCASE("at the end")
@@ -628,6 +651,7 @@ namespace sparrow
                 CHECK_EQ(buffer_adapt[0], 0x04030201);
                 CHECK_EQ(buffer_adapt[1], 0x08070605);
                 CHECK_EQ(buffer_adapt[2], to_insert);
+                CHECK_EQ(buf.size(), 12);
             }
         }
 
@@ -646,6 +670,11 @@ namespace sparrow
                         CHECK_EQ(result, buffer_adapt.begin());
                         REQUIRE_EQ(buffer_adapt.size(), 1);
                         CHECK_EQ(buffer_adapt[0], 0x08070605);
+                        CHECK_EQ(buf.size(), 4);
+                        CHECK_EQ(buf[0], 0x05);
+                        CHECK_EQ(buf[1], 0x06);
+                        CHECK_EQ(buf[2], 0x07);
+                        CHECK_EQ(buf[3], 0x08);
                     }
 
                     SUBCASE("in the middle")
@@ -657,6 +686,11 @@ namespace sparrow
                         CHECK_EQ(result, std::next(buffer_adapt.begin()));
                         REQUIRE_EQ(buffer_adapt.size(), 1);
                         CHECK_EQ(buffer_adapt[0], 0x04030201);
+                        REQUIRE_EQ(buf.size(), 4);
+                        CHECK_EQ(buf[0], 0x01);
+                        CHECK_EQ(buf[1], 0x02);
+                        CHECK_EQ(buf[2], 0x03);
+                        CHECK_EQ(buf[3], 0x04);
                     }
 
                     SUBCASE("at the end")
@@ -668,6 +702,11 @@ namespace sparrow
                         CHECK_EQ(result, buffer_adapt.end());
                         REQUIRE_EQ(buffer_adapt.size(), 1);
                         CHECK_EQ(buffer_adapt[0], 0x04030201);
+                        REQUIRE_EQ(buf.size(), 4);
+                        CHECK_EQ(buf[0], 0x01);
+                        CHECK_EQ(buf[1], 0x02);
+                        CHECK_EQ(buf[2], 0x03);
+                        CHECK_EQ(buf[3], 0x04);
                     }
                 }
 
@@ -679,6 +718,7 @@ namespace sparrow
                     const buffer_adaptor<uint32_t, decltype(buf)&>::iterator result = buffer_adapt.erase(it);
                     CHECK_EQ(result, buffer_adapt.end());
                     CHECK(buffer_adapt.empty());
+                    CHECK(buf.empty());
                 }
             }
 
@@ -698,6 +738,7 @@ namespace sparrow
                         );
                         CHECK_EQ(result, buffer_adapt.end());
                         CHECK(buffer_adapt.empty());
+                        CHECK_EQ(buf.size(), 0);
                     }
 
                     SUBCASE("in the middle")
@@ -714,6 +755,7 @@ namespace sparrow
                         REQUIRE_EQ(buffer_adapt.size(), 2);
                         CHECK_EQ(buffer_adapt[0], 0x04030201);
                         CHECK_EQ(buffer_adapt[1], 0x0C0B0A09);
+                        CHECK_EQ(buf.size(), 8);
                     }
 
                     SUBCASE("at the end")
@@ -730,6 +772,7 @@ namespace sparrow
                         REQUIRE_EQ(buffer_adapt.size(), 2);
                         CHECK_EQ(buffer_adapt[0], 0x04030201);
                         CHECK_EQ(buffer_adapt[1], 0x08070605);
+                        CHECK_EQ(buf.size(), 8);
                     }
                 }
 
@@ -758,6 +801,11 @@ namespace sparrow
             CHECK_EQ(buffer_adapt[0], 0x04030201);
             CHECK_EQ(buffer_adapt[1], 0x08070605);
             CHECK_EQ(buffer_adapt[2], 0x05040302);
+
+            CHECK_EQ(buf[8], 0x02);
+            CHECK_EQ(buf[9], 0x03);
+            CHECK_EQ(buf[10], 0x04);
+            CHECK_EQ(buf[11], 0x05);
         }
 
         TEST_CASE("pop_back")
@@ -767,6 +815,7 @@ namespace sparrow
             buffer_adapt.pop_back();
             REQUIRE_EQ(buffer_adapt.size(), 1);
             CHECK_EQ(buffer_adapt[0], 0x04030201);
+            CHECK_EQ(buf.size(), 4);
         }
 
         TEST_CASE("resize")
@@ -781,6 +830,7 @@ namespace sparrow
                 CHECK_EQ(buffer_adapt[1], 0x08070605);
                 CHECK_EQ(buffer_adapt[2], 0x00000000);
                 CHECK_EQ(buffer_adapt[3], 0x00000000);
+                CHECK_EQ(buf.size(), 16);
             }
 
             SUBCASE("new_size and value")
@@ -792,6 +842,7 @@ namespace sparrow
                 CHECK_EQ(buffer_adapt[1], 0x08070605);
                 CHECK_EQ(buffer_adapt[2], value);
                 CHECK_EQ(buffer_adapt[3], value);
+                CHECK_EQ(buf.size(), 16);
             }
         }
 

--- a/test/test_mpl.cpp
+++ b/test/test_mpl.cpp
@@ -189,4 +189,10 @@ namespace sparrow
     static_assert(mpl::testable<std::optional<int>>);
     static_assert(mpl::testable<std::shared_ptr<int>>);
     static_assert(not mpl::testable<std::vector<int>>);
+
+    // T_matches_qualifier_if_Y_is
+    static_assert(mpl::T_matches_qualifier_if_Y_is<int, int, std::is_const>);
+    static_assert(not mpl::T_matches_qualifier_if_Y_is<int, const int, std::is_const>);
+    static_assert(mpl::T_matches_qualifier_if_Y_is<const int, const int, std::is_const>);
+    static_assert(mpl::T_matches_qualifier_if_Y_is<const int, int, std::is_const>);
 }


### PR DESCRIPTION
buffer_adaptor can now takes as input a const reference to a container. In that case all the const methods are disabled.