### PR TITLE
Nullable range constructor

### DIFF
--- a/examples/typed_array_high_level.cpp
+++ b/examples/typed_array_high_level.cpp
@@ -49,7 +49,7 @@ void example_typed_array_of_strings(){
         }
     }
 }
-/*
+
 void example_typed_array_of_strings_from_nullables(){
 
     using value_type = std::string;
@@ -75,10 +75,10 @@ void example_typed_array_of_strings_from_nullables(){
             std::cout << "missing value" << std::endl;
         }
     }
-}*/
+}
 int main() {
     example_typed_array_of_floats();
     example_typed_array_of_strings();
-    //example_typed_array_of_strings_from_nullables();
+    example_typed_array_of_strings_from_nullables();
     return 0;
 }

--- a/examples/typed_array_high_level.cpp
+++ b/examples/typed_array_high_level.cpp
@@ -17,7 +17,7 @@ void example_typed_array_of_floats(){
     // access the data
     for (auto i = 0; i < array.size(); ++i) {
 
-        if (array.bitmap()[i]) {
+        if (array[i].has_value()) {
             std::cout << array[i].value() << std::endl;
         } else {
            std::cout << "missing value" << std::endl;
@@ -41,7 +41,7 @@ void example_typed_array_of_strings(){
 
     // access the data
     for (auto i = 0; i <array.size(); ++i) {
-        if (array.bitmap()[i]) {
+        if (array[i].has_value()) {
             auto  value = array[i].value();
             std::cout << std::string(value.begin(), value.end()) << std::endl;
         } else {
@@ -68,7 +68,7 @@ void example_typed_array_of_strings_from_nullables(){
 
     // access the data
     for (auto i = 0; i <array.size(); ++i) {
-        if (array.bitmap()[i]) {
+        if (array[i].has_value()) {
             auto  value = array[i].value();
             std::cout << std::string(value.begin(), value.end()) << std::endl;
         } else {

--- a/include/sparrow/array/array_data_factory.hpp
+++ b/include/sparrow/array/array_data_factory.hpp
@@ -32,6 +32,7 @@
 #include "sparrow/layout/dictionary_encoded_layout.hpp"
 #include "sparrow/layout/fixed_size_layout.hpp"
 #include "sparrow/layout/variable_size_binary_layout.hpp"
+#include "sparrow/utils/nullable.hpp"
 #include "sparrow/utils/contracts.hpp"
 #include "sparrow/utils/memory.hpp"
 #include "sparrow/utils/mp_utils.hpp"
@@ -39,34 +40,12 @@
 
 namespace sparrow
 {
-
-    /*
-    * \brief Concept to check if a range is convertible to a range of booleans.
-    *
-    * A range is considered convertible to a range of booleans if it is a range and its value type is convertible to a boolean.
-    *
-    * @tparam BoolRange The range to check.
-    */
-    template<class BoolRange>
-    concept bool_convertible_range = std::ranges::range<BoolRange> &&
-        std::convertible_to<std::ranges::range_value_t<BoolRange>, bool>;
-
-    /*
-    * \brief Concept to check if a range is a range of nullables.
-    *
-    * A range is considered a range of nullables if it is a range and its value type is a nullable.
-    *
-    * @tparam RangeOfNullables The range to check.
-    */
-    template<class RangeOfNullables>
-    concept range_of_nullables = std::ranges::range<RangeOfNullables> && is_nullable<std::ranges::range_value_t<RangeOfNullables>>::value;
-
     /// \cond
     namespace detail
     {
 
         // a helper function to make the bitmap from a range
-        template<bool_convertible_range BoolRange>
+        template<mpl::bool_convertible_range BoolRange>
         requires (!std::is_same_v<std::decay_t<BoolRange>, array_data::bitmap_type>)
         array_data::bitmap_type make_array_data_bitmap(BoolRange&& range)
         {
@@ -182,7 +161,7 @@ namespace sparrow
      * @param offset The offset of the array data.
      * @return The created array_data object.
      */
-    template <range_for_array_data ValueRange, bool_convertible_range BitmapRange>
+    template <range_for_array_data ValueRange, mpl::bool_convertible_range BitmapRange>
     array_data make_array_data_for_fixed_size_layout(
         ValueRange&& values,
         BitmapRange && bitmap,
@@ -260,7 +239,7 @@ namespace sparrow
      * @param offset The offset of the array_data object.
      * @return The created array_data object.
      */
-    template <range_for_array_data ValueRange, bool_convertible_range BitmapRange>
+    template <range_for_array_data ValueRange, mpl::bool_convertible_range BitmapRange>
     array_data make_array_data_for_variable_size_binary_layout(
         ValueRange&& values,
         BitmapRange && bitmap,
@@ -445,7 +424,7 @@ namespace sparrow
      * @param offset The offset for the array data.
      * @return The created array_data object.
      */
-    template <range_for_array_data ValueRange, bool_convertible_range BitmapRange>
+    template <range_for_array_data ValueRange, mpl::bool_convertible_range BitmapRange>
     array_data make_array_data_for_dictionary_encoded_layout(
         ValueRange&& values,
         BitmapRange && bitmap,
@@ -532,7 +511,7 @@ namespace sparrow
      * @param offset The offset for the array data.
      * @return The created array data object.
      */
-    template <arrow_layout Layout, range_for_array_data ValueRange, bool_convertible_range BitmapRange>
+    template <arrow_layout Layout, range_for_array_data ValueRange, mpl::bool_convertible_range BitmapRange>
     array_data
     make_default_array_data(ValueRange&& values, BitmapRange && bitmap, std::int64_t offset)
     {
@@ -570,7 +549,7 @@ namespace sparrow
      * @param bitmap The input range of values for the bitmap to indicate missing values.
      * @return A new array_data object with the specified layout, values, bitmap, and offset.
      */
-    template <arrow_layout Layout, std::ranges::input_range ValueRange, bool_convertible_range BitmapRange>
+    template <arrow_layout Layout, std::ranges::input_range ValueRange, mpl::bool_convertible_range BitmapRange>
     array_data
     make_default_array_data(ValueRange&& values, BitmapRange && bitmap)
     {

--- a/include/sparrow/array/array_data_factory.hpp
+++ b/include/sparrow/array/array_data_factory.hpp
@@ -45,13 +45,10 @@ namespace sparrow
     concept bool_convertible_range = std::ranges::range<BoolRange> &&
         std::convertible_to<std::ranges::range_value_t<BoolRange>, bool>;
 
-    
     // a range of nullable values / nullable<T>
     template<class RangeOfNullables>
     concept range_of_nullables = std::ranges::range<RangeOfNullables> && is_nullable<std::ranges::range_value_t<RangeOfNullables>>::value;
         
-        
-
     namespace detail
     {
 

--- a/include/sparrow/array/array_data_factory.hpp
+++ b/include/sparrow/array/array_data_factory.hpp
@@ -206,15 +206,12 @@ namespace sparrow
         auto data = buffer.data<T>();
         auto value_iter = values.begin();
         auto bitmap_iter = bitmap.begin();
-        for (std::size_t i = 0; i < size; ++i)
+        for (std::size_t i = 0; i < size; ++i, ++bitmap_iter, ++value_iter, ++data)
         {
             if (*bitmap_iter)
             {
                 *data = *value_iter;
             }
-            ++bitmap_iter;
-            ++data;
-            ++value_iter;
         }
         buffers[0] = std::move(buffer);
 

--- a/include/sparrow/array/array_data_factory.hpp
+++ b/include/sparrow/array/array_data_factory.hpp
@@ -265,7 +265,6 @@ namespace sparrow
 
         std::vector<array_data::buffer_type> buffers(2);
         buffers[0].resize(sizeof(std::int64_t) * (values_size + 1), 0);
-        // we accumulate by hand otherwise we might access a missing value
         size_t acc_size = 0; 
         auto bitmap_iter = bitmap.begin();
         auto value_iter = values.begin();

--- a/include/sparrow/array/array_data_factory.hpp
+++ b/include/sparrow/array/array_data_factory.hpp
@@ -40,15 +40,28 @@
 namespace sparrow
 {
 
-    // a range where the value type is convertible to bool
+    /*
+    * \brief Concept to check if a range is convertible to a range of booleans.
+    *
+    * A range is considered convertible to a range of booleans if it is a range and its value type is convertible to a boolean.
+    *
+    * @tparam BoolRange The range to check.
+    */
     template<class BoolRange>
     concept bool_convertible_range = std::ranges::range<BoolRange> &&
         std::convertible_to<std::ranges::range_value_t<BoolRange>, bool>;
 
-    // a range of nullable values / nullable<T>
+    /*
+    * \brief Concept to check if a range is a range of nullables.
+    *
+    * A range is considered a range of nullables if it is a range and its value type is a nullable.
+    *
+    * @tparam RangeOfNullables The range to check.
+    */
     template<class RangeOfNullables>
     concept range_of_nullables = std::ranges::range<RangeOfNullables> && is_nullable<std::ranges::range_value_t<RangeOfNullables>>::value;
-        
+
+    /// \cond
     namespace detail
     {
 
@@ -78,8 +91,8 @@ namespace sparrow
         {
             return std::forward<Bitmap>(bitmap);
         }
-
     }
+    /// \endcond
 
     /**
      * Concept to check if a layout is a supported layout.
@@ -551,13 +564,13 @@ namespace sparrow
 
 
     /**
-     * \brief Creates a default array_data object with the specified layout and values and indicate which values are null.
+     * \brief Creates a default array_data object with the specified layout and values and indicate which values are missing.
      *
      * @tparam Layout The layout of the array_data object.
      * @tparam ValueRange The type of the input range for the values.
      * @tparam BitmapRange The type of the input range for the bitmap.
      * @param values The input range of values for the array_data object.
-     * @param bitmap The input range of values for the bitmap.
+     * @param bitmap The input range of values for the bitmap to indicate missing values.
      * @return A new array_data object with the specified layout, values, bitmap, and offset.
      */
     template <arrow_layout Layout, std::ranges::input_range ValueRange, bool_convertible_range BitmapRange>
@@ -569,16 +582,16 @@ namespace sparrow
     }
 
     /*
-    * \brief Creates a default array_data object with the specified layout and values.
+    * \brief Creates a default array_data object with the specified layout and values and indicate which values are missing.
     *
     * @tparam Layout The layout of the array_data object.
-    * @tparam ValueRange The type of the input range for the values.
+    * @tparam RangeOfNullables The type of the input range for the values.
     * @param values The input range of values for the array_data object.
     * @return A new array_data object with the specified layout, values, bitmap, and offset.
     */
-    template<arrow_layout Layout, range_of_nullables ValueRange>
-    requires std::convertible_to<typename std::ranges::range_value_t<ValueRange>::value_type, typename Layout::inner_value_type>
-    array_data make_default_array_data(ValueRange&& values)
+    template<arrow_layout Layout, range_of_nullables RangeOfNullables>
+    requires std::convertible_to<typename std::ranges::range_value_t<RangeOfNullables>::value_type, typename Layout::inner_value_type>
+    array_data make_default_array_data(RangeOfNullables&& values)
     {
         // transform range of nullable to range of values
         auto values_range = values | std::views::transform([](auto&& nullable) { return nullable.value(); });

--- a/include/sparrow/array/array_data_factory.hpp
+++ b/include/sparrow/array/array_data_factory.hpp
@@ -253,7 +253,7 @@ namespace sparrow
     template <range_for_array_data ValueRange, bool_convertible_range BitmapRange>
     array_data make_array_data_for_variable_size_binary_layout(
         ValueRange&& values,
-        BitmapRange && bitmap,        
+        BitmapRange && bitmap,
         std::int64_t offset
     )
     {
@@ -273,9 +273,6 @@ namespace sparrow
                 return value;
             }
         };
-
-
-        
 
         std::vector<array_data::buffer_type> buffers(2);
         buffers[0].resize(sizeof(std::int64_t) * (values_size + 1), 0);

--- a/include/sparrow/array/array_data_factory.hpp
+++ b/include/sparrow/array/array_data_factory.hpp
@@ -60,7 +60,7 @@ namespace sparrow
         array_data::bitmap_type make_array_data_bitmap(BoolRange&& range)
         {
             array_data::bitmap_type bitmap(std::ranges::size(range), true);
-            for(size_t i = 0; auto value : range)
+            for(std::size_t i = 0; auto value : range)
             {
                 if(!value)
                 {
@@ -283,7 +283,7 @@ namespace sparrow
         size_t acc_size = 0; 
         auto bitmap_iter = bitmap.begin();
         auto value_iter = values.begin();
-        for(size_t i = 0; i < values_size; ++i)
+        for(std::size_t i = 0; i < values_size; ++i)
         {
             if(*bitmap_iter)
             {

--- a/include/sparrow/array/array_data_factory.hpp
+++ b/include/sparrow/array/array_data_factory.hpp
@@ -146,7 +146,7 @@ namespace sparrow
     {
         if (!values.empty())
         {
-            const size_t expected_size = values.front().size();
+            const std::size_t expected_size = values.front().size();
             return std::ranges::all_of(
                 values,
                 [expected_size](const auto& value)
@@ -188,12 +188,12 @@ namespace sparrow
 
 
         std::vector<array_data::buffer_type> buffers(1);
-        const size_t buffer_size = (size * sizeof(T)) / sizeof(uint8_t);
+        const std::size_t buffer_size = (size * sizeof(T)) / sizeof(uint8_t);
         array_data::buffer_type buffer(buffer_size);
         auto data = buffer.data<T>();
         auto value_iter = values.begin();
         auto bitmap_iter = bitmap.begin();
-        for (size_t i = 0; i < size; ++i)
+        for (std::size_t i = 0; i < size; ++i)
         {
             if (*bitmap_iter)
             {
@@ -357,7 +357,7 @@ namespace sparrow
         }
 
         std::vector<std::reference_wrapper<V>> values;
-        std::vector<size_t> indexes;
+        std::vector<std::size_t> indexes;
     };
 
     /**
@@ -383,7 +383,7 @@ namespace sparrow
             set_index.emplace(std::cref(value), 0);
         }
 
-        for (size_t i = 0; auto& [_, value] : set_index)
+        for (std::size_t i = 0; auto& [_, value] : set_index)
         {
             value = i;
             ++i;
@@ -457,9 +457,9 @@ namespace sparrow
         const auto& indexes = vec_and_indexes.indexes;
         const auto create_buffer = [&indexes]()
         {
-            const size_t buffer_size = indexes.size() * sizeof(size_t) / sizeof(uint8_t);
+            const std::size_t buffer_size = indexes.size() * sizeof(std::size_t) / sizeof(uint8_t);
             array_data::buffer_type b(buffer_size);
-            std::ranges::copy(indexes, b.data<size_t>());
+            std::ranges::copy(indexes, b.data<std::size_t>());
             return b;
         };
         return {
@@ -632,7 +632,7 @@ namespace sparrow
         typename Layout::size_type n
         ,  T && value)
     {
-        auto repeated_range = std::ranges::iota_view{size_t(0),size_t(n)} | std::views::transform([&](auto) { return value; });
+        auto repeated_range = std::ranges::iota_view{std::size_t(0),std::size_t(n)} | std::views::transform([&](auto) { return value; });
 
         return make_default_array_data<Layout>(repeated_range);
     }

--- a/include/sparrow/array/array_data_factory.hpp
+++ b/include/sparrow/array/array_data_factory.hpp
@@ -539,7 +539,7 @@ namespace sparrow
 
 
     /**
-     * \brief Creates a default array_data object with the specified layout and values and indicate which values are missing.
+     * Creates a default array_data object with the specified layout and values and indicate which values are missing.
      *
      * @tparam Layout The layout of the array_data object.
      * @tparam ValueRange The type of the input range for the values.

--- a/include/sparrow/array/typed_array.hpp
+++ b/include/sparrow/array/typed_array.hpp
@@ -103,10 +103,14 @@ namespace sparrow
          */
         template <std::ranges::input_range ValueRange>
         requires  
-            range_for_array_data<ValueRange> && 
+            (range_for_array_data<ValueRange>  || (range_of_nullables<ValueRange> &&  std::convertible_to<typename std::ranges::range_value_t<ValueRange>::value_type,T>))
+             && 
             std::same_as<array_data, typename L::data_storage_type> &&
             (!is_typed_array_impl_v<ValueRange>)
         typed_array_impl(ValueRange&& values);
+
+
+
 
 
         /** Construct a typed array with a fixed layout with the same value repeated `n` times.
@@ -313,7 +317,7 @@ namespace sparrow
     template <is_arrow_base_type T, arrow_layout L>
     template <std::ranges::input_range ValueRange>
     requires  
-        range_for_array_data<ValueRange> && 
+        (range_for_array_data<ValueRange>  || (range_of_nullables<ValueRange> &&  std::convertible_to<typename std::ranges::range_value_t<ValueRange>::value_type,T>)) &&
         std::same_as<array_data, typename L::data_storage_type> &&
         (!is_typed_array_impl_v<ValueRange>)
     typed_array_impl<T, L>::typed_array_impl(ValueRange&& values)   

--- a/include/sparrow/array/typed_array.hpp
+++ b/include/sparrow/array/typed_array.hpp
@@ -102,16 +102,18 @@ namespace sparrow
          * @param values The range of values to construct the array from.
          */
         template <std::ranges::input_range ValueRange>
+        // in simple words: either a range of values or a range of nullable values but not a typed array
         requires  
-            (range_for_array_data<ValueRange>  || (range_of_nullables<ValueRange> &&  std::convertible_to<typename std::ranges::range_value_t<ValueRange>::value_type,T>))
-             && 
-            std::same_as<array_data, typename L::data_storage_type> &&
-            (!is_typed_array_impl_v<ValueRange>)
+            (   
+                range_for_array_data<ValueRange>  || 
+                (
+                    range_of_nullables<ValueRange> 
+                    &&  std::convertible_to<typename std::ranges::range_value_t<ValueRange>::value_type,T>
+                )
+            )
+            && std::same_as<array_data, typename L::data_storage_type> 
+            && (!is_typed_array_impl_v<ValueRange>)
         typed_array_impl(ValueRange&& values);
-
-
-
-
 
         /** Construct a typed array with a fixed layout with the same value repeated `n` times.
          *
@@ -316,17 +318,22 @@ namespace sparrow
 
     template <is_arrow_base_type T, arrow_layout L>
     template <std::ranges::input_range ValueRange>
+    // in simple words: either a range of values or a range of nullable values but not a typed array
     requires  
-        (range_for_array_data<ValueRange>  || (range_of_nullables<ValueRange> &&  std::convertible_to<typename std::ranges::range_value_t<ValueRange>::value_type,T>)) &&
-        std::same_as<array_data, typename L::data_storage_type> &&
-        (!is_typed_array_impl_v<ValueRange>)
+        (
+            range_for_array_data<ValueRange>  || 
+            (
+                range_of_nullables<ValueRange> 
+                &&  std::convertible_to<typename std::ranges::range_value_t<ValueRange>::value_type,T>
+            )
+        )
+        && std::same_as<array_data, typename L::data_storage_type> 
+        && (!is_typed_array_impl_v<ValueRange>)
     typed_array_impl<T, L>::typed_array_impl(ValueRange&& values)   
         : m_data(make_default_array_data<L>(std::forward<ValueRange>(values)))
         , m_layout(m_data) 
     {
     }
-
-
 
     template <is_arrow_base_type T, arrow_layout L>
     template<class U>

--- a/include/sparrow/utils/mp_utils.hpp
+++ b/include/sparrow/utils/mp_utils.hpp
@@ -421,12 +421,10 @@ namespace sparrow::mpl
 #endif
     }
 
-
     /// Matches range types whose elements are convertible to bool.
     template<class BoolRange>
     concept bool_convertible_range = std::ranges::range<BoolRange> &&
         std::convertible_to<std::ranges::range_value_t<BoolRange>, bool>;
-
 
     /// Matches types that can be convertible to and assignable from bool. We do not use
     /// `std::convertible_to` because we don't want to impose an implicit conversion.

--- a/include/sparrow/utils/mp_utils.hpp
+++ b/include/sparrow/utils/mp_utils.hpp
@@ -421,6 +421,13 @@ namespace sparrow::mpl
 #endif
     }
 
+
+    /// Matches range types whose elements are convertible to bool.
+    template<class BoolRange>
+    concept bool_convertible_range = std::ranges::range<BoolRange> &&
+        std::convertible_to<std::ranges::range_value_t<BoolRange>, bool>;
+
+
     /// Matches types that can be convertible to and assignable from bool. We do not use
     /// `std::convertible_to` because we don't want to impose an implicit conversion.
     template <class T>

--- a/include/sparrow/utils/nullable.hpp
+++ b/include/sparrow/utils/nullable.hpp
@@ -56,6 +56,17 @@ namespace sparrow
     concept is_nullable_of_convertible_to = is_nullable_v<N> &&  std::convertible_to<typename N::value_type, T>;
 
     /*
+    * \brief Concept to check if a range is a range of nullables.
+    *
+    * A range is considered a range of nullables if it is a range and its value type is a nullable.
+    *
+    * @tparam RangeOfNullables The range to check.
+    */
+    template<class RangeOfNullables>
+    concept range_of_nullables = std::ranges::range<RangeOfNullables> && is_nullable<std::ranges::range_value_t<RangeOfNullables>>::value;
+
+
+    /*
      * Default traits for the nullable class. These traits should be specialized
      * for proxy classes whose reference and const_reference types are not
      * defined as usual. For instance:

--- a/include/sparrow/utils/nullable.hpp
+++ b/include/sparrow/utils/nullable.hpp
@@ -56,7 +56,7 @@ namespace sparrow
     concept is_nullable_of_convertible_to = is_nullable_v<N> &&  std::convertible_to<typename N::value_type, T>;
 
     /*
-    * \brief Concept to check if a range is a range of nullables.
+    * Matches a range of nullables objects.
     *
     * A range is considered a range of nullables if it is a range and its value type is a nullable.
     *

--- a/test/test_typed_array.cpp
+++ b/test/test_typed_array.cpp
@@ -67,8 +67,8 @@ TEST_SUITE("typed_array")
         typed_array<uint32_t, Layout> ta_for_dels;
         CHECK_EQ(ta_for_dels.size(), 0);
     }
-
-    /*TEST_CASE("constructor from range of nullable fixed_size_layout"){
+    
+    TEST_CASE("constructor from range of nullable fixed_size_layout"){
         using nt = nullable<int32_t>;
         SUBCASE("some missing")
         {
@@ -129,6 +129,7 @@ TEST_SUITE("typed_array")
             CHECK_EQ(ta[3].value(), 3);
         }
     }
+    
     TEST_CASE("constructor from range of nullable variable_size_binary_layout"){
         using nt = nullable<std::string>;
         SUBCASE("some missing")
@@ -181,8 +182,8 @@ TEST_SUITE("typed_array")
             CHECK(ta[3].has_value());
             CHECK_EQ(ta[3].value(), "dddd");
         }
-    }*/
-
+    }
+    
     TEST_CASE_TEMPLATE_DEFINE("all", T, all)
     {
         SUBCASE("default constructor for fixed_size_layout")

--- a/test/test_variable_size_binary_layout.cpp
+++ b/test/test_variable_size_binary_layout.cpp
@@ -157,6 +157,13 @@ namespace sparrow
             layout_type l(m_data);
             const layout_type& cl = l;
 
+            SUBCASE("sanity")
+            {
+                CHECK_EQ(cl[0].value(), words[1]);
+                CHECK_EQ(cl[1].has_value(), true);
+                CHECK_EQ(cl[1].value().size(), 0);
+            }
+
             SUBCASE("size")
             {
                 
@@ -166,6 +173,7 @@ namespace sparrow
 
             SUBCASE("iterator")
             {
+                
                 auto ref0 = l[0].value();
                 auto cref0 = cl[0].value();
                 auto cref1 = cl[1].value();
@@ -173,7 +181,7 @@ namespace sparrow
                 auto it_end = ref0.end();
                 std::fill(it, it_end, 'a');
                 CHECK_EQ(cref0, "aaa");
-                CHECK_EQ(cref1, words[2]);
+                CHECK_EQ(cref1, "");
             }
 
             SUBCASE("const_iterator")
@@ -200,7 +208,7 @@ namespace sparrow
                 auto ref0 = l[0].value();
                 ref0 = "coi";
                 CHECK_EQ(cl[0].value(), "coi");
-                CHECK_EQ(cl[1].value(), words[2]);
+                CHECK_EQ(cl[1].value(), "");
                 CHECK_EQ(cl[2].value(), words[3]);
             }
 
@@ -209,7 +217,7 @@ namespace sparrow
                 auto ref0 = l[0].value();
                 ref0 = "coin";
                 CHECK_EQ(cl[0].value(), "coin");
-                CHECK_EQ(cl[1].value(), words[2]);
+                CHECK_EQ(cl[1].value(), "");
                 CHECK_EQ(cl[2].value(), words[3]);
             }
 
@@ -218,7 +226,7 @@ namespace sparrow
                 auto ref0 = l[0].value();
                 ref0 = "am";
                 CHECK_EQ(cl[0].value(), "am");
-                CHECK_EQ(cl[1].value(), words[2]);
+                CHECK_EQ(cl[1].value(),"");
                 CHECK_EQ(cl[2].value(), words[3]);
             }
 
@@ -235,7 +243,7 @@ namespace sparrow
 
                 CHECK_EQ(ref0.value(), words[0]);
                 CHECK_EQ(ref1.value(), words[1]);
-                CHECK_EQ(ref2.value(), words[2]);
+                CHECK_EQ(ref2.value(), "");
                 CHECK_EQ(ref3.value(), std::string("unpreparedandmore"));
 
                 ref0.value() = std::string("he");


### PR DESCRIPTION
* use a range of bools instead of a bitmap in the factory functions:
    * this allows to split a vector<nullable<T>> into two ranges, the values and the bitmaps
    * this can then be passed to pre-existing factory functions
    * note that this changes how the length of missing values is accounted for in the dynamic layout (see below)   


This changes some behavior:
```
  values = ["fo", "bar", "fubar"]
  bitmap  = [1,0,1]  
```

used to account space  for "bar" in the offsets.
This PR changes this st. we will **not take** the length of "bar" into account since its a missing value (ie the effective length will be 0)

Why? This is the only consistent way of doing it:

Consider a range of nullables:
```C++
std::vector<nullable<std::string>> {
   nullable("fo"), nullval, nullval("fubar")
}
```
Here it's clear that we cannot give the missing value any length in the offsets, therefore we should also not account for space in the case above. 

* due to this behavior change the test for the dynamic layout had to be changed
