### PR TITLE
Begin work on v0.0.4

### DIFF
--- a/include/sparrow/config/sparrow_version.hpp
+++ b/include/sparrow/config/sparrow_version.hpp
@@ -18,5 +18,5 @@ namespace sparrow
 {
     constexpr int SPARROW_VERSION_MAJOR = 0;
     constexpr int SPARROW_VERSION_MINOR = 0;
-    constexpr int SPARROW_VERSION_PATCH = 3;
+    constexpr int SPARROW_VERSION_PATCH = 4;
 }


### PR DESCRIPTION
Makes sure it's clear that `main` is now work on v0.0.4