### PR TITLE
32bit support

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -118,8 +118,18 @@ jobs:
         echo "VCPKG_TARGET_TRIPLET='x86-windows'" >> $GITHUB_ENV
         echo "CMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" >> $GITHUB_ENV
 
+    - name: Enable runtime size/length/offset validity checks
+      if: matrix.config.name == 'Debug'
+      run: |
+        echo "SPARROW_CHECKS='$SPARROW_CHECKS -DSPAROW_ENABLE_SIZE_CHECKS=ON'" >> $GITHUB_ENV
+
+    - name: Enable runtime 32bit size/length/offset limit
+      if: matrix.target-arch.name == 'Win32' # Note: this is not a mandatory limitation in any context, we add this just to have at least one configuration testing that feature
+      run: |
+        echo "SPARROW_CHECKS='$SPARROW_CHECKS -DSPAROW_ENABLE_32BIT_SIZE_LIMIT=ON'" >> $GITHUB_ENV
+
     - name: Configure using CMake
-      run: cmake -S ./ -B ./build -DCMAKE_BUILD_TYPE:STRING=${{matrix.config.name}} -DCMAKE_PREFIX_PATH=$SPARROW_DEPS_PREFIX -DCMAKE_INSTALL_PREFIX=$SPARROW_INSTALL_PREFIX -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DUSE_DATE_POLYFILL=${{matrix.toolchain.date-polyfill}} -DBUILD_REFACTORING=${{matrix.toolchain.build_refactoring}} -G "${{matrix.build-system.name}}" $GENERATOR_EXTRA_FLAGS
+      run: cmake -S ./ -B ./build -DCMAKE_BUILD_TYPE:STRING=${{matrix.config.name}} -DCMAKE_PREFIX_PATH=$SPARROW_DEPS_PREFIX -DCMAKE_INSTALL_PREFIX=$SPARROW_INSTALL_PREFIX -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DUSE_DATE_POLYFILL=${{matrix.toolchain.date-polyfill}} -DBUILD_REFACTORING=${{matrix.toolchain.build_refactoring}} -G "${{matrix.build-system.name}}" $GENERATOR_EXTRA_FLAGS $SPARROW_CHECKS
 
     - name: Build
       if: matrix.toolchain.build_refactoring == 'ON'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -159,7 +159,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: matrix.toolchain.build_refactoring == 'ON' && (success() || failure())
       with:
-        name: test_sparrow_lib_report_Windows_v01_${{ matrix.toolchain.compiler }}_${{ matrix.target-arch.name }}_${{ matrix.build-system }}_${{ matrix.config.name }}_date-polyfill_${{ matrix.toolchain.date-polyfill}}_refactoring_${{ matrix.toolchain.build_refactoring }}
+        name: test_sparrow_lib_report_Windows_v01_${{ matrix.toolchain.compiler }}_${{ matrix.target-arch.name }}_${{ matrix.build-system.name }}_${{ matrix.config.name }}_date-polyfill_${{ matrix.toolchain.date-polyfill}}_refactoring_${{ matrix.toolchain.build_refactoring }}
         path: '**/test_sparrow_lib_report_v01.xml'
 
     - name: Run all examples

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,46 +13,88 @@ defaults:
 jobs:
   build:
     runs-on: ${{ matrix.runs-on }}
-    name: ${{ matrix.sys.compiler }} / ${{ matrix.build-system }} / ${{ matrix.config.name }} / date-polyfill ${{ matrix.sys.date-polyfill}}
+    name: ${{ matrix.toolchain.compiler }} / ${{ matrix.build-system.name }} / ${{ matrix.config.name }} / targets ${{ matrix.target-arch.name }} /  date-polyfill ${{ matrix.toolchain.date-polyfill}} / Refactoring ${{ matrix.toolchain.build_refactoring }}
     strategy:
       fail-fast: false
       matrix:
         runs-on: [windows-latest]
-        sys:
+        toolchain:
         - { compiler: msvc, date-polyfill: 'ON', build_refactoring: 'OFF' }
         - { compiler: msvc, date-polyfill: 'OFF', build_refactoring: 'ON' }
         - { compiler: clang, date-polyfill: 'ON', version: 17, build_refactoring: 'OFF'}
         - { compiler: clang, date-polyfill: 'OFF', version: 17, build_refactoring: 'ON' }
+        target-arch:
+        - {
+            name: "Win64",
+            vs-flags: "-A x64", # only used by VS generator
+            cl-flags: "/arch (x64)",
+            gnu-flags: "-m64",
+            msvc-dev-cmd: "win64"
+          }
+        - {
+            name: "Win32",
+            vs-flags: "-A Win32", # only used by VS generator
+            cl-flags: "/arch (x86)",
+            gnu-flags: "-m32",
+            msvc-dev-cmd: "win32"
+          }
         config:
         - { name: Debug }
         - { name: Release }
         build-system:
-        - "Visual Studio 17 2022"
-        - "Ninja"
+        - { name: "Visual Studio 17 2022" }
+        - { name: "Ninja" }
 
     steps:
 
-    - name: Setup MSVC
-      if: matrix.sys.compiler == 'msvc' && matrix.build-system != 'Visual Studio 17 2022'
+    - name: Setup MSVC (only for non-VS buildsystems)
+      if: matrix.toolchain.compiler == 'msvc' && !startsWith(matrix.build-system.name, 'Visual Studio')
       uses: ilammy/msvc-dev-cmd@v1
+      with:
+        # Ninja will take cues of which target architecture to use from the (powershell)
+        # msvc environment so we need to setup everything at this level.
+        arch: ${{matrix.target-arch.msvc-dev-cmd}}
 
     - name: Install LLVM and Clang
-      if: matrix.sys.compiler == 'clang'
+      if: matrix.toolchain.compiler == 'clang'
       uses: egor-tensin/setup-clang@v1
       with:
-        version: ${{matrix.sys.version}}
+        version: ${{matrix.toolchain.version}}
         platform: x64
 
     - name: Setup clang
-      if: matrix.sys.compiler == 'clang'
+      if: matrix.toolchain.compiler == 'clang'
       run: |
         echo "CC=clang" >> $GITHUB_ENV
         echo "CXX=clang++" >> $GITHUB_ENV
 
+    - name: Setup gnu compilers
+      if: matrix.toolchain.compiler != 'msvc'
+      run: |
+        echo "CMAKE_CXX_FLAGS=${{matrix.target-arch.gnu-flags}}" >> $GITHUB_ENV
+        echo "CMAKE_CXX_LINK_FLAGS=${{matrix.target-arch.gnu-flags}}" >> $GITHUB_ENV
+
+    - name: Setup Ninja + msvc
+      if: matrix.toolchain.compiler == 'msvc' && matrix.build-system.name == 'Ninja'
+      run: |
+        echo "CMAKE_CXX_FLAGS=${{matrix.target-arch.cl-flags}}" >> $GITHUB_ENV
+        echo "CMAKE_CXX_LINK_FLAGS=${{matrix.target-arch.cl-flags}}" >> $GITHUB_ENV
+
+    - name: Setup Visual Studio
+      if: startsWith(matrix.build-system.name, 'Visual Studio')
+      run: |
+        echo "GENERATOR_EXTRA_FLAGS=${{matrix.target-arch.vs-flags}}" >> $GITHUB_ENV
+
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Setup vcpkg environment
+      if: matrix.target-arch.name == 'Win32'
+      run: |
+        vcpkg install --triplet=x86-windows
+
     - name: Set conda environment
+      if: matrix.target-arch.name == 'Win64'
       uses: mamba-org/setup-micromamba@main
       with:
         environment-name: myenv
@@ -62,11 +104,25 @@ jobs:
         create-args: |
           ninja
 
+    - name: Set dependencies install prefix dir for 64bit
+      if: matrix.target-arch.name == 'Win64'
+      run: |
+        echo "SPARROW_DEPS_PREFIX=$CONDA_PREFIX" >> $GITHUB_ENV
+        echo "SPARROW_INSTALL_PREFIX=$CONDA_PREFIX" >> $GITHUB_ENV
+
+    - name: Set dependencies install prefix dir for 32bit
+      if: matrix.target-arch.name == 'Win32'
+      run: |
+        echo "SPARROW_DEPS_PREFIX=$VCPKG_INSTALLED_DIR" >> $GITHUB_ENV
+        echo "SPARROW_INSTALL_PREFIX=$VCPKG_INSTALLED_DIR" >> $GITHUB_ENV
+        echo "VCPKG_TARGET_TRIPLET='x86-windows'" >> $GITHUB_ENV
+        echo "CMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" >> $GITHUB_ENV
+
     - name: Configure using CMake
-      run: cmake -Bbuild -DCMAKE_BUILD_TYPE:STRING=${{matrix.config.name}} -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON  -DUSE_DATE_POLYFILL=${{matrix.sys.date-polyfill}} -DBUILD_REFACTORING=${{matrix.sys.build_refactoring}} -G "${{matrix.build-system}}"
+      run: cmake -S ./ -B ./build -DCMAKE_BUILD_TYPE:STRING=${{matrix.config.name}} -DCMAKE_PREFIX_PATH=$SPARROW_DEPS_PREFIX -DCMAKE_INSTALL_PREFIX=$SPARROW_INSTALL_PREFIX -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DUSE_DATE_POLYFILL=${{matrix.toolchain.date-polyfill}} -DBUILD_REFACTORING=${{matrix.toolchain.build_refactoring}} -G "${{matrix.build-system.name}}" $GENERATOR_EXTRA_FLAGS
 
     - name: Build
-      if: matrix.sys.build_refactoring == 'ON'
+      if: matrix.toolchain.build_refactoring == 'ON'
       working-directory: build
       run: cmake --build . --config ${{matrix.config.name}} --target sparrow --parallel 8
 
@@ -86,24 +142,24 @@ jobs:
       uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
-        name: test_sparrow_lib_report_Windows_${{ matrix.sys.compiler }}_${{ matrix.build-system }}_${{ matrix.config.name }}_date-polyfill_${{ matrix.sys.date-polyfill}}
+        name: test_sparrow_lib_report_Windows_${{ matrix.toolchain.compiler }}_${{ matrix.build-system.name }}_${{ matrix.config.name }}_${{ matrix.target-arch.name }}_date-polyfill_${{ matrix.toolchain.date-polyfill}}
         path: '**/test_sparrow_lib_report.xml'
 
     - name: Build refactoring
-      if: matrix.sys.build_refactoring == 'ON'
+      if: matrix.toolchain.build_refactoring == 'ON'
       working-directory: build
       run: cmake --build . --config ${{matrix.config.name}} --target test_sparrow_lib_v01 --parallel 8
 
     - name: Run refactoring tests
-      if: matrix.sys.build_refactoring == 'ON'
+      if: matrix.toolchain.build_refactoring == 'ON'
       working-directory: build
       run: cmake --build . --config ${{matrix.config.name}} --target run_tests_with_junit_report_v01
 
     - name: Upload refactoring test results
       uses: actions/upload-artifact@v4
-      if: matrix.sys.build_refactoring == 'ON' && (success() || failure())
+      if: matrix.toolchain.build_refactoring == 'ON' && (success() || failure())
       with:
-        name: test_sparrow_lib_report_Windows_v01_${{ matrix.sys.compiler }}_${{ matrix.build-system }}_${{ matrix.config.name }}_date-polyfill_${{ matrix.sys.date-polyfill}}
+        name: test_sparrow_lib_report_Windows_v01_${{ matrix.toolchain.compiler }}_${{ matrix.target-arch.name }}_${{ matrix.build-system }}_${{ matrix.config.name }}_date-polyfill_${{ matrix.toolchain.date-polyfill}}_refactoring_${{ matrix.toolchain.build_refactoring }}
         path: '**/test_sparrow_lib_report_v01.xml'
 
     - name: Run all examples

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@
 # Clangd cache
 .cache
 CMakeUserPresets.json
+
+# Vcpkg packages
+/vcpkg_installed/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,8 @@ OPTION(BUILD_DOCS  "Build sparrow documentation" OFF)
 OPTION(BUILD_EXAMPLES "Build sparrow examples" OFF)
 OPTION(USE_DATE_POLYFILL "Use date polyfill implementation" ON)
 OPTION(BUILD_REFACTORING "Build the refactoring target" OFF)
+OPTION(SPAROW_ENABLE_SIZE_CHECKS "Enables runtime checks that values of sizes/lengths/offsets from the various C++ types are always in range of the supported Arrow lengths" OFF)
+OPTION(SPAROW_ENABLE_32BIT_SIZE_LIMIT "Once enabled, all the sizes are assumed to be in the range of 32bit representation. Can be checked at runtime with `SPAROW_ENABLE_SIZE_CHECKS=ON`" OFF)
 
 include(CheckCXXSymbolExists)
 
@@ -66,6 +68,7 @@ if(LIBCPP)
   # as some formatter for new types.
   add_compile_definitions(_LIBCPP_DISABLE_AVAILABILITY)
 endif()
+
 
 # Linter options
 # =============
@@ -207,6 +210,16 @@ if (BUILD_TESTS)
         add_subdirectory(test_v01)
     endif ()
 endif ()
+
+if (SPAROW_ENABLE_SIZE_CHECKS)
+    target_compile_definitions(sparrow INTERFACE SPAROW_ENABLE_SIZE_CHECKS 1)
+    message("-> sparrow config: size limit runtime checks enabled (SPAROW_ENABLE_SIZE_CHECKS=ON): sizes will be checked at runtime to be between zero and max(in64_t) (or max(int32_t if SPAROW_ENABLE_32BIT_SIZE_LIMIT=ON)")
+endif()
+
+if (SPAROW_ENABLE_32BIT_SIZE_LIMIT)
+    target_compile_definitions(sparrow INTERFACE SPAROW_ENABLE_32BIT_SIZE_LIMIT)
+    message("-> sparrow config: 32bit size limit enabled (SPAROW_ENABLE_32BIT_SIZE_LIMIT=ON): valid size values are restricted to range zero to max(int32_t)")
+endif()
 
 # Docs
 # ====

--- a/include/sparrow/array/data_type.hpp
+++ b/include/sparrow/array/data_type.hpp
@@ -194,6 +194,12 @@ namespace sparrow
         }
     }
 
+
+#if defined(__GNUC__) && !defined(__clang__)
+#   pragma GCC diagnostic push
+#   pragma GCC diagnostic ignored "-Wuseless-cast" // We want to be able to cast type aliases to their real types.
+#endif
+
     /// @returns The provided arrow length value as represented by the native standard size type `std::size_t`.
     ///          If `config::enable_size_limit_runtime_check == true` it will also check that the value is
     ///          a valid arrow length and representable by `std::size_t` or throws otherwise.
@@ -243,6 +249,10 @@ namespace sparrow
         throw_if_invalid_size<R>(result, false); // dont allow negatives as the result must be a size
         return static_cast<R>(result);
     }
+#if defined(__GNUC__) && !defined(__clang__)
+#    pragma GCC diagnostic pop
+#endif
+
 
     /// Runtime identifier of arrow data types, usually associated with raw bytes with the associated value.
     // TODO: does not support all types specified by the Arrow specification

--- a/include/sparrow/array/external_array_data.hpp
+++ b/include/sparrow/array/external_array_data.hpp
@@ -272,7 +272,7 @@ namespace sparrow
 
     inline void external_array_data::build_children()
     {
-        const auto size = static_cast<std::size_t>(array().n_children);
+        const auto size = to_native_size(array().n_children);
         m_children.reserve(size);
         for (std::size_t i = 0; i < size; ++i)
         {
@@ -327,7 +327,7 @@ namespace sparrow
     {
         using return_type = external_array_data::bitmap_type;
         return return_type(impl::buffer_at(data, 0u),
-                           static_cast<std::size_t>(length(data)));
+                           to_native_size(length(data)));
     }
 
     inline std::size_t buffers_size(const external_array_data& data)
@@ -338,7 +338,7 @@ namespace sparrow
             return std::size_t(0);
         }
         // The first buffer in external data is used for the bitmap
-        return static_cast<std::size_t>(data.array().n_buffers - 1);
+        return sum_arrow_offsets<std::size_t>(data.array().n_buffers, - 1);
     }
 
     inline external_array_data::buffer_type
@@ -347,12 +347,12 @@ namespace sparrow
         using return_type = external_array_data::buffer_type;
         // The first buffer in external data is used for the bitmap
         return return_type(impl::buffer_at(data, i + 1u),
-                           static_cast<std::size_t>(length(data)));
+                           to_native_size(length(data)));
     }
 
     inline std::size_t child_data_size(const external_array_data& data)
     {
-        return static_cast<std::size_t>(data.array().n_children);
+        return to_native_size(data.array().n_children);
     }
 
     inline const external_array_data& child_data_at(const external_array_data& data, std::size_t i)

--- a/include/sparrow/arrow_interface/arrow_array.hpp
+++ b/include/sparrow/arrow_interface/arrow_array.hpp
@@ -168,7 +168,7 @@ namespace sparrow
         array.private_data = new arrow_array_private_data(std::move(buffers));
         const auto private_data = static_cast<arrow_array_private_data*>(array.private_data);
         array.buffers = private_data->buffers_ptrs<void>();
-        array.n_children = static_cast<int64_t>(n_children);
+        array.n_children = to_arrow_length(n_children);
         array.children = children;
         array.dictionary = dictionary;
         array.release = release_arrow_array;
@@ -276,7 +276,7 @@ namespace sparrow
     get_arrow_array_buffers(const ArrowArray& array, const ArrowSchema& schema)
     {
         std::vector<sparrow::buffer_view<uint8_t>> buffers;
-        const auto buffer_count = static_cast<size_t>(array.n_buffers);
+        const auto buffer_count = to_native_size(array.n_buffers);
         buffers.reserve(buffer_count);
         const enum data_type data_type = format_to_data_type(schema.format);
         const std::vector<buffer_type> buffers_type = get_buffer_types_from_data_type(data_type);
@@ -286,8 +286,8 @@ namespace sparrow
             auto buffer = array.buffers[i];
             const std::size_t buffer_size = compute_buffer_size(
                 buffer_type,
-                static_cast<size_t>(array.length),
-                static_cast<size_t>(array.offset),
+                to_native_size(array.length),
+                to_native_size(array.offset),
                 data_type
             );
             auto* ptr = static_cast<uint8_t*>(const_cast<void*>(buffer));
@@ -310,7 +310,7 @@ namespace sparrow
         target.n_children = source_array.n_children;
         if (source_array.n_children > 0)
         {
-            target.children = new ArrowArray*[static_cast<std::size_t>(source_array.n_children)];
+            target.children = new ArrowArray*[ to_native_size(source_array.n_children) ];
             for (int64_t i = 0; i < source_array.n_children; ++i)
             {
                 SPARROW_ASSERT_TRUE(source_array.children[i] != nullptr);
@@ -331,7 +331,7 @@ namespace sparrow
         target.n_buffers = source_array.n_buffers;
 
         std::vector<buffer<std::uint8_t>> buffers_copy;
-        buffers_copy.reserve(static_cast<std::size_t>(source_array.n_buffers));
+        buffers_copy.reserve(to_native_size(source_array.n_buffers));
         const auto buffers = get_arrow_array_buffers(source_array, source_schema);
         for (const auto& buffer : buffers)
         {

--- a/include/sparrow/arrow_interface/arrow_array_schema_info_utils.hpp
+++ b/include/sparrow/arrow_interface/arrow_array_schema_info_utils.hpp
@@ -24,7 +24,7 @@ namespace sparrow
     constexpr bool validate_buffers_count(data_type data_type, int64_t n_buffers)
     {
         const std::size_t expected_buffer_count = get_expected_buffer_count(data_type);
-        return static_cast<std::size_t>(n_buffers) == expected_buffer_count;
+        return to_native_size(n_buffers) == expected_buffer_count;
     }
 
     /// @returns The the expected number of children for a given data type.
@@ -71,7 +71,7 @@ namespace sparrow
     inline bool validate_format_with_arrow_array(data_type data_type, const ArrowArray& array)
     {
         const bool buffers_count_valid = validate_buffers_count(data_type, array.n_buffers);
-        const bool children_count_valid = static_cast<std::size_t>(array.n_children)
+        const bool children_count_valid = to_native_size(array.n_children)
                                           == get_expected_children_count(data_type);
         return buffers_count_valid && children_count_valid;
     }

--- a/include/sparrow/arrow_interface/arrow_array_schema_utils.hpp
+++ b/include/sparrow/arrow_interface/arrow_array_schema_utils.hpp
@@ -29,7 +29,7 @@ namespace sparrow
 {
     /**
      * Release the children and dictionnary of an `ArrowArray` or `ArrowSchema`.
-     * 
+     *
      * @tparam T `ArrowArray` or `ArrowSchema`
      * @param t The `ArrowArray` or `ArrowSchema` to release.
      */
@@ -41,7 +41,7 @@ namespace sparrow
         {
             return;
         }
-        
+
         if (t.dictionary)
         {
             if (t.dictionary->release)

--- a/include/sparrow/arrow_interface/arrow_schema.hpp
+++ b/include/sparrow/arrow_interface/arrow_schema.hpp
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 
+#include "sparrow/array/data_type.hpp"
 #include "sparrow/arrow_interface/arrow_array_schema_utils.hpp"
 #include "sparrow/arrow_interface/arrow_schema/private_data.hpp"
 #include "sparrow/arrow_interface/arrow_schema/smart_pointers.hpp"
@@ -151,7 +152,7 @@ namespace sparrow
         schema.dictionary = dictionary;
         schema.release = release_arrow_schema;
     }
-    
+
 
     inline void release_arrow_schema(ArrowSchema* schema)
     {
@@ -250,7 +251,7 @@ namespace sparrow
         target.n_children = source.n_children;
         if (source.n_children > 0)
         {
-            target.children = new ArrowSchema*[static_cast<std::size_t>(source.n_children)];
+            target.children = new ArrowSchema*[ to_native_size(source.n_children) ];
             for (int64_t i = 0; i < source.n_children; ++i)
             {
                 SPARROW_ASSERT_TRUE(source.children[i] != nullptr);

--- a/include/sparrow/buffer/buffer.hpp
+++ b/include/sparrow/buffer/buffer.hpp
@@ -335,7 +335,7 @@ namespace sparrow
     template <class T>
     buffer_base<T>::~buffer_base()
     {
-        deallocate(m_data.p_begin, static_cast<size_type>(m_data.p_storage_end - m_data.p_begin));
+        deallocate(m_data.p_begin, static_cast<size_type>(std::distance(m_data.p_begin, m_data.p_storage_end)));
     }
 
     template <class T>

--- a/include/sparrow/buffer/dynamic_bitset.hpp
+++ b/include/sparrow/buffer/dynamic_bitset.hpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <utility>
 
+#include "sparrow/array/data_type.hpp"
 #include "sparrow/buffer/buffer.hpp"
 #include "sparrow/buffer/buffer_view.hpp"
 #include "sparrow/utils/contracts.hpp"
@@ -519,12 +520,16 @@ namespace sparrow
     constexpr dynamic_bitset_base<B>::dynamic_bitset_base(storage_type&& buf, size_type size)
         : m_buffer(std::move(buf))
         , m_size(size)
-        , m_null_count(m_size - count_non_null())
     {
         if constexpr (!std::is_const_v<block_type>)
         {
             zero_unused_bits();
         }
+
+        const auto null_count = count_non_null();
+        m_null_count = m_size - null_count;
+        SPARROW_ASSERT_TRUE(is_valid_arrow_length(size));
+        SPARROW_ASSERT_TRUE(is_valid_arrow_length(m_null_count));
     }
 
     template <random_access_range B>
@@ -533,6 +538,8 @@ namespace sparrow
         , m_size(size)
         , m_null_count(null_count)
     {
+        SPARROW_ASSERT_TRUE(is_valid_arrow_length(size));
+        SPARROW_ASSERT_TRUE(is_valid_arrow_length(m_null_count));
         if constexpr (!std::is_const_v<block_type>)
         {
             zero_unused_bits();
@@ -593,6 +600,7 @@ namespace sparrow
         {
             res += table[*p];
         }
+        SPARROW_ASSERT_TRUE(is_valid_arrow_length(res));
         return res;
     }
 

--- a/include/sparrow/c_interface.hpp
+++ b/include/sparrow/c_interface.hpp
@@ -92,10 +92,10 @@ namespace sparrow
     /// through `ArrowArray` and `ArrowSchema`
     struct arrow_data_ownership
     {
-        ///< Specifies if the ownership of the schema data
+        /// Specifies if the ownership of the schema data
         ownership schema = ownership::not_owning;
 
-        ///< Specifies if the ownership of the array data
+        /// Specifies if the ownership of the array data
         ownership array = ownership::not_owning;
     };
 

--- a/include/sparrow/config/config.hpp
+++ b/include/sparrow/config/config.hpp
@@ -38,7 +38,37 @@
 #   define SPARROW_API __attribute__((visibility("default")))
 #endif
 
-consteval bool is_apple_compiler()
+namespace sparrow
 {
-    return static_cast<bool>(COMPILING_WITH_APPLE_CLANG);
+    consteval bool is_apple_compiler()
+    {
+        return static_cast<bool>(COMPILING_WITH_APPLE_CLANG);
+    }
+
+    namespace config
+    {
+        inline constexpr bool enable_size_limit_runtime_check =
+#if defined(SPAROW_ENABLE_SIZE_CHECKS)
+#   if SPAROW_ENABLE_SIZE_CHECKS == 1
+            true
+#   else
+            false
+#   endif
+#else
+#   ifndef NDEBUG // if not specified, by default in debug builds, we enable these checks
+            true
+#   else
+            false
+#   endif
+#endif
+            ;
+
+        inline constexpr bool enable_32bit_size_limit =
+#if defined(SPAROW_ENABLE_32BIT_SIZE_LIMIT)
+            true
+#else
+            false
+#endif
+            ;
+    }
 }

--- a/include/sparrow/layout/fixed_size_layout.hpp
+++ b/include/sparrow/layout/fixed_size_layout.hpp
@@ -141,7 +141,7 @@ namespace sparrow
     {
         // We only require the presence of the bitmap and the first buffer.
         SPARROW_ASSERT_TRUE(buffers_size(storage()) > 0);
-        SPARROW_ASSERT_TRUE(static_cast<size_type>(length(storage())) == sparrow::bitmap(storage()).size())
+        SPARROW_ASSERT_TRUE(to_native_size(length(storage())) == sparrow::bitmap(storage()).size())
     }
 
     template <class T, data_storage DS>
@@ -154,21 +154,21 @@ namespace sparrow
     auto fixed_size_layout<T, DS>::size() const -> size_type
     {
         SPARROW_ASSERT_TRUE(offset(storage()) <= length(storage()));
-        return static_cast<size_type>(length(storage()) - offset(storage()));
+        return sum_arrow_offsets<size_type>(length(storage()), -offset(storage()));
     }
 
     template <class T, data_storage DS>
     auto fixed_size_layout<T, DS>::value(size_type i) -> inner_reference
     {
         SPARROW_ASSERT_TRUE(i < size());
-        return data()[i + static_cast<size_type>(offset(storage()))];
+        return data()[ sum_arrow_offsets<size_type>(i, offset(storage())) ];
     }
 
     template <class T, data_storage DS>
     auto fixed_size_layout<T, DS>::value(size_type i) const -> inner_const_reference
     {
         SPARROW_ASSERT_TRUE(i < size());
-        return data()[i + static_cast<size_type>(offset(storage()))];
+        return data()[ sum_arrow_offsets<size_type>(i, offset(storage())) ];
     }
 
     template <class T, data_storage DS>
@@ -238,20 +238,20 @@ namespace sparrow
     auto fixed_size_layout<T, DS>::has_value(size_type i) -> bitmap_reference
     {
         SPARROW_ASSERT_TRUE(i < size());
-        return sparrow::bitmap(storage())[i + static_cast<size_type>(offset(storage()))];
+        return sparrow::bitmap(storage())[ sum_arrow_offsets<size_type>(i, offset(storage())) ];
     }
 
     template <class T, data_storage DS>
     auto fixed_size_layout<T, DS>::has_value(size_type i) const -> bitmap_const_reference
     {
         SPARROW_ASSERT_TRUE(i < size());
-        return sparrow::bitmap(storage())[i + static_cast<size_type>(offset(storage()))];
+        return sparrow::bitmap(storage())[ sum_arrow_offsets<size_type>( i, offset(storage())) ];
     }
 
     template <class T, data_storage DS>
     auto fixed_size_layout<T, DS>::value_begin() -> value_iterator
     {
-        return value_iterator{data() + offset(storage())};
+        return value_iterator{data() + to_native_offset(offset(storage()))};
     }
 
     template <class T, data_storage DS>
@@ -263,7 +263,7 @@ namespace sparrow
     template <class T, data_storage DS>
     auto fixed_size_layout<T, DS>::value_cbegin() const -> const_value_iterator
     {
-        return const_value_iterator{data() + offset(storage())};
+        return const_value_iterator{data() + to_native_offset(offset(storage()))};
     }
 
     template <class T, data_storage DS>
@@ -275,7 +275,7 @@ namespace sparrow
     template <class T, data_storage DS>
     auto fixed_size_layout<T, DS>::bitmap_begin() -> bitmap_iterator
     {
-        return sparrow::next(sparrow::bitmap(storage()).begin(), offset(storage()));
+        return sparrow::next(sparrow::bitmap(storage()).begin(), to_native_offset(offset(storage())));
     }
 
     template <class T, data_storage DS>
@@ -287,7 +287,7 @@ namespace sparrow
     template <class T, data_storage DS>
     auto fixed_size_layout<T, DS>::bitmap_cbegin() const -> const_bitmap_iterator
     {
-        return sparrow::next(sparrow::bitmap(storage()).cbegin(), offset(storage()));
+        return sparrow::next(sparrow::bitmap(storage()).cbegin(), to_native_offset(offset(storage())));
     }
 
     template <class T, data_storage DS>

--- a/include/sparrow/layout/list_layout/list_layout_value_iterator.hpp
+++ b/include/sparrow/layout/list_layout/list_layout_value_iterator.hpp
@@ -36,13 +36,13 @@ namespace sparrow
     template<class LIST_LAYOUT_TYPE, class CHILD_LAYOUT_TYPE, class OFFSET_TYPE, bool IS_CONST>
     class list_layout_value_iterator: public iterator_base<
             // derived
-            list_layout_value_iterator<LIST_LAYOUT_TYPE, CHILD_LAYOUT_TYPE, OFFSET_TYPE , IS_CONST>, 
+            list_layout_value_iterator<LIST_LAYOUT_TYPE, CHILD_LAYOUT_TYPE, OFFSET_TYPE , IS_CONST>,
             // element
             list_value_t<CHILD_LAYOUT_TYPE, IS_CONST>,
             // category
             std::random_access_iterator_tag,
             // REFERENCE
-            list_value_t<CHILD_LAYOUT_TYPE, IS_CONST> 
+            list_value_t<CHILD_LAYOUT_TYPE, IS_CONST>
         >
     {
         public:
@@ -67,15 +67,16 @@ namespace sparrow
             self_type& operator=(const self_type& rhs) = default;
 
             list_value_type dereference() const
-            {   
+            {
                 child_layout_reference child_layout = p_layout->m_child_layout;
                 const auto offset = p_layout->element_offset(m_index);
                 const auto length = p_layout->element_length(m_index);
 
-                
+
                 return list_value_type(
-                    sparrow::next(child_layout.begin(), offset),
-                    sparrow::next(child_layout.begin(), offset + length));
+                    sparrow::next(child_layout.begin(), to_native_offset(offset)),
+                    sparrow::next(child_layout.begin(), to_native_offset(offset + length))
+                );
             }
 
             bool equal(const self_type& rhs) const
@@ -87,23 +88,27 @@ namespace sparrow
             {
                 ++m_index;
             }
+
             void decrement()
             {
-                --m_index; 
+                --m_index;
             }
+
             void advance(std::ptrdiff_t n)
             {
                 m_index += static_cast<size_type>(n);
             }
+
             std::ptrdiff_t distance_to(const self_type& rhs) const
             {
                 return static_cast<ptrdiff_t>(rhs.m_index) - static_cast<std::ptrdiff_t>(m_index);
             }
+
             bool less_than(const self_type& rhs) const
             {
                 return m_index < rhs.m_index;
             }
-            
+
         private:
             using list_layout_type = LIST_LAYOUT_TYPE;
 

--- a/include/sparrow/layout/null_layout.hpp
+++ b/include/sparrow/layout/null_layout.hpp
@@ -196,7 +196,7 @@ namespace sparrow
     template <data_storage DS>
     auto null_layout<DS>::size() const -> size_type
     {
-        return static_cast<size_type>(length(storage()));
+        return to_native_size(length(storage()));
     }
 
     template <data_storage DS>

--- a/include/sparrow/utils/bit.hpp
+++ b/include/sparrow/utils/bit.hpp
@@ -36,7 +36,7 @@ namespace sparrow
         std::ranges::reverse(value_representation);
         return std::bit_cast<T>(value_representation);
     }
-    
+
     template <std::endian input_value_endianess>
     constexpr auto to_native_endian(std::integral auto value) noexcept
     {

--- a/include/sparrow/utils/nullable.hpp
+++ b/include/sparrow/utils/nullable.hpp
@@ -236,7 +236,7 @@ namespace sparrow
      * private:
      *     std::vector<T> m_values;
      *     std::vector<bool> m_flags;
-     * 
+     *
      * public:
      *
      *     using reference = nullable<double&, bool&>;
@@ -287,21 +287,21 @@ namespace sparrow
         using flag_const_reference = typename flag_traits::const_reference;
         using flag_rvalue_reference = typename flag_traits::rvalue_reference;
         using flag_const_rvalue_reference = typename flag_traits::const_rvalue_reference;
-        
+
         template <std::default_initializable U = T, std::default_initializable BB = B>
         constexpr nullable() noexcept
             : m_value()
             , m_null_flag(false)
         {
         }
-        
+
         template <std::default_initializable U = T, std::default_initializable BB = B>
         constexpr nullable(nullval_t) noexcept
             : m_value()
             , m_null_flag(false)
         {
         }
-        
+
         template <class U>
         requires (
             not std::same_as<self_type, std::decay_t<U>> and
@@ -436,7 +436,7 @@ namespace sparrow
         constexpr const_reference get() const & noexcept;
         constexpr rvalue_reference get() && noexcept;
         constexpr const_rvalue_reference get() const && noexcept;
-        
+
         constexpr reference value() &;
         constexpr const_reference value() const &;
         constexpr rvalue_reference value() &&;
@@ -470,7 +470,7 @@ namespace sparrow
 
     template <class T, mpl::boolean_like B>
     constexpr std::strong_ordering operator<=>(const nullable<T, B>& lhs, nullval_t) noexcept;
-    
+
     template <class T, class B, class U>
     constexpr bool operator==(const nullable<T, B>& lhs, const U& rhs) noexcept;
 
@@ -490,7 +490,7 @@ namespace sparrow
     // to their argument, making the deduction impossible.
     template <class T, mpl::boolean_like B = bool>
     constexpr nullable<T, B> make_nullable(T&& value, B&& flag = true);
-    
+
     /**
      * variant of nullable, exposing has_value for convenience
      *
@@ -536,13 +536,13 @@ namespace sparrow
     {
         return m_null_flag;
     }
-    
+
     template <class T, mpl::boolean_like B>
     constexpr auto nullable<T, B>::null_flag() const & noexcept -> flag_const_reference
     {
         return m_null_flag;
     }
-    
+
     template <class T, mpl::boolean_like B>
     constexpr auto nullable<T, B>::null_flag() && noexcept -> flag_rvalue_reference
     {
@@ -555,7 +555,7 @@ namespace sparrow
             return flag_rvalue_reference(m_null_flag);
         }
     }
-    
+
     template <class T, mpl::boolean_like B>
     constexpr auto nullable<T, B>::null_flag() const && noexcept -> flag_const_rvalue_reference
     {
@@ -580,7 +580,7 @@ namespace sparrow
     {
         return m_value;
     }
-    
+
     template <class T, mpl::boolean_like B>
     constexpr auto nullable<T, B>::get() && noexcept -> rvalue_reference
     {
@@ -620,7 +620,7 @@ namespace sparrow
         throw_if_null();
         return get();
     }
-    
+
     template <class T, mpl::boolean_like B>
     constexpr auto nullable<T, B>::value() && -> rvalue_reference
     {
@@ -639,14 +639,14 @@ namespace sparrow
     template <class U>
     constexpr auto nullable<T, B>::value_or(U&& default_value) const & -> value_type
     {
-        return *this ? get() : value_type(std::forward<U>(default_value)); 
+        return *this ? get() : value_type(std::forward<U>(default_value));
     }
 
     template <class T, mpl::boolean_like B>
     template <class U>
     constexpr auto nullable<T, B>::value_or(U&& default_value) && -> value_type
     {
-        return *this ? get() : value_type(std::forward<U>(default_value)); 
+        return *this ? get() : value_type(std::forward<U>(default_value));
     }
 
     template <class T, mpl::boolean_like B>
@@ -662,7 +662,7 @@ namespace sparrow
     {
         m_null_flag = false;
     }
-    
+
     template <class T, mpl::boolean_like B>
     void nullable<T, B>::throw_if_null() const
     {
@@ -689,7 +689,7 @@ namespace sparrow
     {
         return lhs <=> false;
     }
-    
+
     template <class T, class B, class U>
     constexpr bool operator==(const nullable<T, B>& lhs, const U& rhs) noexcept
     {
@@ -744,7 +744,7 @@ namespace sparrow
         base_type::operator=(std::move(rhs));
         return *this;
     }
-    
+
     template <class... T>
     requires (is_nullable_v<T> && ...)
     constexpr nullable_variant<T...>::operator bool() const

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,7 @@ set(SPARROW_TESTS_SOURCES
     test_arrow_array_schema_utils.cpp
     test_arrow_array.cpp
     test_arrow_schema.cpp
+    test_arrow_length.cpp
     test_bit.cpp
     test_buffer_adaptor.cpp
     test_buffer.cpp
@@ -75,7 +76,7 @@ set(SPARROW_TESTS_SOURCES
 set(test_target "test_sparrow_lib")
 add_executable(${test_target} ${SPARROW_TESTS_SOURCES})
 target_link_libraries(${test_target}
-    PRIVATE 
+    PRIVATE
         sparrow doctest::doctest $<$<BOOL:USE_SANITIZER>:${SANITIZER_LINK_LIBRARIES}>)
 
 include(doctest)

--- a/test/array_data_creation.cpp
+++ b/test/array_data_creation.cpp
@@ -58,8 +58,8 @@ namespace sparrow::test
         }
 
         ad.buffers.push_back(b);
-        ad.length = static_cast<std::int64_t>(n);
-        ad.offset = static_cast<std::int64_t>(offset);
+        ad.length = to_arrow_length(n);
+        ad.offset = to_arrow_length(offset);
         ad.child_data.emplace_back();
         return ad;
     }

--- a/test/test_arrow_array.cpp
+++ b/test/test_arrow_array.cpp
@@ -291,14 +291,16 @@ TEST_SUITE("C Data Interface")
             CHECK_EQ(array.n_children , array_copy.n_children);
             CHECK_NE(array.buffers , array_copy.buffers);
             CHECK_NE(array.private_data , array_copy.private_data);
-            for(size_t i = 0; i < static_cast<size_t>(array.n_buffers); ++i)
+            const auto buffer_count = sparrow::to_native_size(array.n_buffers);
+            for (size_t i = 0; i < buffer_count; ++i)
             {
                 CHECK_NE(array.buffers[i] , array_copy.buffers[i]);
             }
             auto array_buffers = reinterpret_cast<const int8_t**>(array.buffers);
             auto array_copy_buffers = reinterpret_cast<const int8_t**>(array_copy.buffers);
 
-            for(size_t i = 0; i < static_cast<size_t>(array.length); ++i)
+            const auto length = sparrow::to_native_size(array.length);
+            for(size_t i = 0; i < length; ++i)
             {
                 CHECK_EQ(array_buffers[1][i], array_copy_buffers[1][i]);
             }

--- a/test/test_arrow_length.cpp
+++ b/test/test_arrow_length.cpp
@@ -67,6 +67,48 @@ TEST_SUITE("value_ptr")
         ));
     }
 
+    TEST_CASE("throw_if_invalid_size")
+    {
+        using namespace sparrow;
+        throw_if_invalid_size(0);
+        throw_if_invalid_size(1);
+        throw_if_invalid_size(1024);
+        throw_if_invalid_size(std::numeric_limits<std::int32_t>::max());
+        throw_if_invalid_size(max_arrow_length);
 
+        CHECK_THROWS(throw_if_invalid_size(-1));
+        CHECK_THROWS(throw_if_invalid_size(-1024));
+        CHECK_THROWS(throw_if_invalid_size(std::numeric_limits<std::int32_t>::min()));
+        throw_if_invalid_size(-1, arrow_length_kind::offset);
+        throw_if_invalid_size(-1024, arrow_length_kind::offset);
+        throw_if_invalid_size(std::numeric_limits<std::int32_t>::min(), arrow_length_kind::offset);
+
+        throw_if_invalid_size(std::size_t{0});
+        throw_if_invalid_size(std::size_t{1});
+        throw_if_invalid_size(std::ptrdiff_t{0});
+        throw_if_invalid_size(std::ptrdiff_t{1});
+        throw_if_invalid_size(std::ptrdiff_t{-1}, arrow_length_kind::offset);
+
+        // When not contrained to 32bit length and native offsets can represent less or equal values of arrow
+        // lengh, we check that the native offset types are usable as expected as arrow length.
+        if constexpr (sizeof(std::ptrdiff_t) <= max_arrow_length and config::enable_32bit_size_limit == false)
+        {
+            throw_if_invalid_size(std::numeric_limits<std::ptrdiff_t>::max());
+            throw_if_invalid_size(std::numeric_limits<std::ptrdiff_t>::max(), arrow_length_kind::offset);
+            throw_if_invalid_size(std::numeric_limits<std::ptrdiff_t>::min(), arrow_length_kind::offset);
+        }
+
+        // We always support at least 32bit lengths
+        throw_if_invalid_size(std::size_t(std::numeric_limits<std::int32_t>::max()));
+        throw_if_invalid_size(std::ptrdiff_t(std::numeric_limits<std::int32_t>::max()));
+        throw_if_invalid_size(
+            std::ptrdiff_t(std::numeric_limits<std::int32_t>::max()),
+            arrow_length_kind::offset
+        );
+        throw_if_invalid_size(
+            std::ptrdiff_t(std::numeric_limits<std::int32_t>::min()),
+            arrow_length_kind::offset
+        );
+    }
 
 }

--- a/test/test_arrow_length.cpp
+++ b/test/test_arrow_length.cpp
@@ -1,0 +1,72 @@
+// Copyright 2024 Man Group Operations Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstddef>
+#include <vector>
+
+#include "doctest/doctest.h"
+
+#include "sparrow/array/data_type.hpp"
+
+
+
+TEST_SUITE("value_ptr")
+{
+    TEST_CASE("is_valid_arrow_length")
+    {
+        using namespace sparrow;
+        CHECK(is_valid_arrow_length(0));
+        CHECK(is_valid_arrow_length(1));
+        CHECK(is_valid_arrow_length(1024));
+        CHECK(is_valid_arrow_length(std::numeric_limits<std::int32_t>::max()));
+        CHECK(is_valid_arrow_length(max_arrow_length));
+
+        CHECK_FALSE(is_valid_arrow_length(-1));
+        CHECK_FALSE(is_valid_arrow_length(-1024));
+        CHECK_FALSE(is_valid_arrow_length(std::numeric_limits<std::int32_t>::min()));
+        CHECK(is_valid_arrow_length(-1, arrow_length_kind::offset));
+        CHECK(is_valid_arrow_length(-1024, arrow_length_kind::offset));
+        CHECK(is_valid_arrow_length(std::numeric_limits<std::int32_t>::min(), arrow_length_kind::offset));
+
+        CHECK(is_valid_arrow_length(std::size_t{0}));
+        CHECK(is_valid_arrow_length(std::size_t{1}));
+        CHECK(is_valid_arrow_length(std::ptrdiff_t{0}));
+        CHECK(is_valid_arrow_length(std::ptrdiff_t{1}));
+        CHECK(is_valid_arrow_length(std::ptrdiff_t{-1}, arrow_length_kind::offset));
+
+        // When not contrained to 32bit length and native offsets can represent less or equal values of arrow lengh,
+        // we check that the native offset types are usable as expected as arrow length.
+        if constexpr( sizeof(std::ptrdiff_t) <= max_arrow_length and config::enable_32bit_size_limit == false )
+        {
+            CHECK(is_valid_arrow_length(std::numeric_limits<std::ptrdiff_t>::max()));
+            CHECK(is_valid_arrow_length(std::numeric_limits<std::ptrdiff_t>::max(), arrow_length_kind::offset));
+            CHECK(is_valid_arrow_length(std::numeric_limits<std::ptrdiff_t>::min(), arrow_length_kind::offset));
+        }
+
+        // We always support at least 32bit lengths
+        CHECK(is_valid_arrow_length(std::size_t(std::numeric_limits<std::int32_t>::max())));
+        CHECK(is_valid_arrow_length(std::ptrdiff_t(std::numeric_limits<std::int32_t>::max())));
+        CHECK(is_valid_arrow_length(
+            std::ptrdiff_t(std::numeric_limits<std::int32_t>::max()),
+            arrow_length_kind::offset
+        ));
+        CHECK(is_valid_arrow_length(
+            std::ptrdiff_t(std::numeric_limits<std::int32_t>::min()),
+            arrow_length_kind::offset
+        ));
+    }
+
+
+
+}

--- a/test/test_dictionary_encoded_layout.cpp
+++ b/test/test_dictionary_encoded_layout.cpp
@@ -70,14 +70,14 @@ namespace sparrow
 
             for (size_t i = 0; i < lwords.size(); ++i)
             {
-                offset()[i + 1] = offset()[i] + static_cast<std::int64_t>(lwords[i].size());
+                offset()[i + 1] = sum_arrow_offsets(offset()[i], lwords[i].size());
                 std::ranges::copy(lwords[i], iter);
                 iter += static_cast<array_data::buffer_type::difference_type>(lwords[i].size());
                 dictionary.bitmap.set(i, true);
             }
             dictionary.bitmap.set(4, false);
 
-            dictionary.length = static_cast<int64_t>(lwords.size());
+            dictionary.length = to_arrow_length(lwords.size());
             dictionary.offset = 0;
             return dictionary;
         }

--- a/test/test_fixed_size_layout.cpp
+++ b/test/test_fixed_size_layout.cpp
@@ -51,7 +51,7 @@ namespace sparrow
             auto buffer_data = ad.buffers[0].data<data_type_t>();
             for (std::size_t i = 0; i < lt.size(); ++i)
             {
-                CHECK_EQ(lt[i].value(), buffer_data[i + static_cast<size_t>(ad.offset)]);
+                CHECK_EQ(lt[i].value(), buffer_data[ sum_arrow_offsets<size_t>(i, ad.offset) ]);
             }
         }
 
@@ -65,7 +65,7 @@ namespace sparrow
             auto buffer_data = ad2.buffers[0].data<data_type_t>();
             for (std::size_t i = 0; i < lt.size(); ++i)
             {
-                CHECK_EQ(lt[i].value(), buffer_data[i + static_cast<size_t>(ad2.offset)]);
+                CHECK_EQ(lt[i].value(), buffer_data[ sum_arrow_offsets<size_t>(i, ad2.offset) ]);
             }
         }
 

--- a/test/test_list_layout.cpp
+++ b/test/test_list_layout.cpp
@@ -29,21 +29,21 @@
 
 namespace sparrow
 {
-   
+
 TEST_SUITE("list_layout")
 {
     // this test will be invoked for each **scalar** type.
-    // Since this test uses  a "fixed_size_layout" as the inner layout, 
+    // Since this test uses  a "fixed_size_layout" as the inner layout,
     // it will **not** work for non-scalar types (ie std::string)
     TEST_CASE_TEMPLATE_DEFINE("generic-scalar-test", T, generic_scalar_test)
     {
         SUBCASE("list<T>")
-        { 
+        {
 
             auto d = test::iota_vector<T>(11);
             std::vector<std::vector<T>> values = {
-                {d[0],d[1], d[2], d[3]}, 
-                {d[4], d[5]}, 
+                {d[0],d[1], d[2], d[3]},
+                {d[4], d[5]},
                 {d[6], d[7], d[8], d[9], d[10]}
             };
 
@@ -77,38 +77,38 @@ TEST_SUITE("list_layout")
             {
                 test::layout_tester(list_layout);
             }
-    
+
         }
         SUBCASE("list<list<T>>")
         {
             auto d = test::iota_vector<T>(28);
             std::vector<std::vector<std::vector<T>>> values = {
                 {
-                    {d[0],d[1], d[2], d[3]}, 
+                    {d[0],d[1], d[2], d[3]},
                     {d[4], d[5], d[6]},
                     {d[7], d[8], d[9], d[10]}
                 },
                 {
-                    {d[11],d[12], d[13], d[14]}, 
-                    {d[15], d[16]}, 
+                    {d[11],d[12], d[13], d[14]},
+                    {d[15], d[16]},
                     {d[17], d[18], d[19], d[20], d[21]}
                 },
                 {
-                    {d[22],d[23], d[24], d[25]}, 
+                    {d[22],d[23], d[24], d[25]},
                     {d[26], d[27]}
                 }
             };
 
             auto outer_list_array_data = test::make_array_data_for_list_of_list_of_scalars(values);
-        
+
             using data_storage = sparrow::array_data;
             using inner_layout_type = sparrow::fixed_size_layout<T, data_storage>;
             using inner_list_layout_type = sparrow::list_layout<inner_layout_type, data_storage,  std::int64_t>;
             using outer_list_layout_type = sparrow::list_layout<inner_list_layout_type, data_storage,  std::int64_t>;
-            
+
             outer_list_layout_type outer_list_layout(outer_list_array_data);
             REQUIRE_EQ(outer_list_layout.size(), values.size());
-            
+
             SUBCASE("operator[]")
             {
                 for(std::size_t i = 0; i < values.size(); i++)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+    "dependencies": [
+      "doctest",
+      "date",
+      {
+        "name": "vcpkg-tool-ninja",
+        "host": true
+      }
+    ]
+  }


### PR DESCRIPTION
- [ ] CI builds and tests 32bit flavor of the current configurations (assuming all host platforms are 64bit)
  - [x] Windows builds
  - [ ] Linux builds
  - [ ] MacOS builds
- [x] fix #175 :
  - support 32bit-only sizes
  - provides a way for user to specify if they want to enable 64bit sizes on 64bit target platforms, or if they want to restrict all sizes under 32bit, whatever the platform;
  - provides a way for user to enable/disable runtime checks on the size values that must be under 32bit.
 - [ ] tests for conversion functions
