### PR TITLE
Implemented cloning_ptr

### DIFF
--- a/include/sparrow_v01/utils/memory.hpp
+++ b/include/sparrow_v01/utils/memory.hpp
@@ -14,10 +14,305 @@
 
 #pragma once
 
+#include <compare>
+#include <concepts>
+#include <memory>
+
 namespace sparrow
 {
-    inline int dummy()
+    /**
+     * Matches types that provide a `clone` method.
+     *
+     * This concept checks if a type provides a `clone` method that
+     * returns a pointer convertible to a pointer to the type.
+     *
+     * @tparam T The type to check
+     */
+    template <class T>
+    concept clonable = requires(const T* t)
     {
-        return 0;
+        { t->clone() } -> std::convertible_to<T*>;
+    };
+
+    /**
+     * @brief smart pointer behaving like a deep copiable std::unique_ptr.
+     * 
+     * `cloning_ptr` owns and manages another object through a pointer, like
+     * `std::unique_ptr`. The difference with `std::unique_ptr` is that 
+     * `cloning_ptr`calls the `clone` method of the managed object upon copy.
+     * 
+     * @tparam T The type of the object managed by the `cloning_ptr`. It must
+     * satisfy the `clonable` concept.
+     */
+    template <clonable T>
+    class cloning_ptr
+    {
+    public:
+
+        using self_type = cloning_ptr<T>;
+        using internal_pointer = std::unique_ptr<T>;
+        using pointer = typename internal_pointer::pointer;
+        using element_type = typename internal_pointer::element_type;
+
+        // Value semantic
+
+        constexpr cloning_ptr() noexcept = default;
+        constexpr cloning_ptr(std::nullptr_t) noexcept;
+        explicit constexpr cloning_ptr(pointer p) noexcept;
+
+        constexpr ~cloning_ptr() = default;
+
+        constexpr cloning_ptr(const self_type& rhs) noexcept;
+        constexpr cloning_ptr(self_type&& rhs) noexcept = default;
+
+        template <class U>
+        requires std::convertible_to<typename cloning_ptr<U>::pointer, pointer>
+        constexpr cloning_ptr(const cloning_ptr<U>& rhs) noexcept;
+
+        template <class U>
+        requires std::convertible_to<typename cloning_ptr<U>::pointer, pointer>
+        constexpr cloning_ptr(cloning_ptr<U>&& rhs) noexcept;
+
+        constexpr self_type& operator=(const self_type&) noexcept;
+        constexpr self_type& operator=(self_type&&) noexcept = default;
+        constexpr self_type& operator=(std::nullptr_t) noexcept;
+
+        template <class U>
+        requires std::convertible_to<typename cloning_ptr<U>::pointer, pointer>
+        constexpr self_type& operator=(const cloning_ptr<U>& rhs) noexcept;
+
+        template <class U>
+        requires std::convertible_to<typename cloning_ptr<U>::pointer, pointer>
+        constexpr self_type& operator=(cloning_ptr<U>&& rhs) noexcept;
+
+        // Modifiers
+
+        constexpr pointer release() noexcept;
+        constexpr void reset(pointer ptr = pointer()) noexcept;
+        void swap(self_type&) noexcept;
+
+        // Observers
+
+        constexpr pointer get() const noexcept;
+
+        constexpr explicit operator bool() const noexcept;
+
+        constexpr std::add_lvalue_reference_t<T>
+        operator*() const noexcept(noexcept(*std::declval<pointer>()));
+        
+        constexpr pointer operator->() const noexcept;
+
+    private:
+
+        constexpr internal_pointer& ptr_impl() noexcept;
+        constexpr const internal_pointer& ptr_impl() const noexcept;
+
+        internal_pointer m_data;
+    };
+
+    template <class T>
+    void swap(cloning_ptr<T>& lhs, cloning_ptr<T>& rhs) noexcept;
+
+    template <class T1, class T2>
+    requires std::equality_comparable_with<
+        typename cloning_ptr<T1>::pointer,
+        typename cloning_ptr<T2>::pointer>
+    constexpr
+    bool operator==(const cloning_ptr<T1>& lhs, const cloning_ptr<T2>& rhs) noexcept;
+
+    template <class T1, class T2>
+    requires std::three_way_comparable_with<
+        typename cloning_ptr<T1>::pointer,
+        typename cloning_ptr<T2>::pointer>
+    constexpr
+    std::compare_three_way_result_t<
+        typename cloning_ptr<T1>::pointer,
+        typename cloning_ptr<T2>::pointer>
+    operator<=>(const cloning_ptr<T1>& lhs, const cloning_ptr<T2>& rhs) noexcept;
+
+    template <class T>
+    constexpr
+    bool operator==(const cloning_ptr<T>& lhs, std::nullptr_t) noexcept;
+
+    template <class T>
+    requires std::three_way_comparable<typename cloning_ptr<T>::pointer>
+    constexpr
+    std::compare_three_way_result_t<typename cloning_ptr<T>::pointer>
+    operator<=>(const cloning_ptr<T>& lhs, std::nullptr_t) noexcept;
+
+    /******************************
+     * cloning_ptr implementation *
+     ******************************/
+
+    template <clonable T>
+    constexpr cloning_ptr<T>::cloning_ptr(std::nullptr_t) noexcept
+        : m_data(nullptr)
+    {
+    }
+
+    template <clonable T>
+    constexpr cloning_ptr<T>::cloning_ptr(pointer p) noexcept
+        : m_data(p)
+    {
+    }
+
+    template <clonable T>
+    constexpr cloning_ptr<T>::cloning_ptr(const cloning_ptr& rhs) noexcept
+        : m_data(rhs->clone())
+    {
+    }
+
+    template <clonable T>
+    template <class U>
+    requires std::convertible_to<typename cloning_ptr<U>::pointer, typename cloning_ptr<T>::pointer>
+    constexpr cloning_ptr<T>::cloning_ptr(const cloning_ptr<U>& rhs) noexcept
+        : m_data(rhs->clone())
+    {
+    }
+    
+    template <clonable T>
+    template <class U>
+    requires std::convertible_to<typename cloning_ptr<U>::pointer, typename cloning_ptr<T>::pointer>
+    constexpr cloning_ptr<T>::cloning_ptr(cloning_ptr<U>&& rhs) noexcept
+        : m_data(rhs.release())
+    {
+    }
+
+    template <clonable T>
+    constexpr auto cloning_ptr<T>::operator=(const self_type& rhs) noexcept -> self_type&
+    {
+        reset(rhs->clone());
+        return *this;
+    }
+
+    template <clonable T>
+    constexpr auto cloning_ptr<T>::operator=(std::nullptr_t) noexcept -> self_type&
+    {
+        reset(nullptr);
+        return *this;
+    }
+
+    template <clonable T>
+    template <class U>
+    requires std::convertible_to<typename cloning_ptr<U>::pointer, typename cloning_ptr<T>::pointer>
+    constexpr auto cloning_ptr<T>::operator=(const cloning_ptr<U>& rhs) noexcept -> self_type&
+    {
+        reset(rhs->clone());
+        return *this;
+    }
+
+    template <clonable T>
+    template <class U>
+    requires std::convertible_to<typename cloning_ptr<U>::pointer, typename cloning_ptr<T>::pointer>
+    constexpr auto cloning_ptr<T>::operator=(cloning_ptr<U>&& rhs) noexcept -> self_type&
+    {
+        reset(rhs.release());
+        return *this;
+    }
+
+    template <clonable T>
+    constexpr auto cloning_ptr<T>::release() noexcept -> pointer
+    {
+        return ptr_impl().release();
+    }
+
+    template <clonable T>
+    constexpr void cloning_ptr<T>::reset(pointer ptr) noexcept
+    {
+        ptr_impl().reset(ptr);
+    }
+
+    template <clonable T>
+    void cloning_ptr<T>::swap(self_type& other) noexcept
+    {
+        using std::swap;
+        swap(ptr_impl(), other.ptr_impl());
+    }
+
+    template <clonable T>
+    constexpr auto cloning_ptr<T>::get() const noexcept -> pointer
+    {
+        return ptr_impl().get();
+    }
+
+    template <clonable T>
+    constexpr cloning_ptr<T>::operator bool() const noexcept
+    {
+        return bool(ptr_impl());
+    }
+
+    template <clonable T>
+    constexpr std::add_lvalue_reference_t<T>
+    cloning_ptr<T>::operator*() const noexcept(noexcept(*std::declval<pointer>()))
+    {
+        return *get();
+    }
+    
+    template <clonable T>
+    constexpr auto cloning_ptr<T>::operator->() const noexcept -> pointer
+    {
+        return get();
+    }
+    
+    template <clonable T>
+    constexpr auto cloning_ptr<T>::ptr_impl() noexcept -> internal_pointer&
+    {
+        return m_data;
+    }
+
+    template <clonable T>
+    constexpr auto cloning_ptr<T>::ptr_impl() const noexcept -> const internal_pointer&
+    {
+        return m_data;
+    }
+
+    /*********************************
+     * Free functions implementation *
+     *********************************/
+
+    template <class T>
+    void swap(cloning_ptr<T>& lhs, cloning_ptr<T>& rhs) noexcept
+    {
+        lhs.swap(rhs);
+    }
+
+    template <class T1, class T2>
+    requires std::equality_comparable_with<
+        typename cloning_ptr<T1>::pointer,
+        typename cloning_ptr<T2>::pointer>
+    constexpr
+    bool operator==(const cloning_ptr<T1>& lhs, const cloning_ptr<T2>& rhs) noexcept
+    {
+        return lhs.get() == rhs.get();
+    }
+
+    template <class T1, class T2>
+    requires std::three_way_comparable_with<
+        typename cloning_ptr<T1>::pointer,
+        typename cloning_ptr<T2>::pointer>
+    constexpr
+    std::compare_three_way_result_t<
+        typename cloning_ptr<T1>::pointer,
+        typename cloning_ptr<T2>::pointer>
+    operator<=>(const cloning_ptr<T1>& lhs, const cloning_ptr<T2>& rhs) noexcept
+    {
+        return lhs.get() <=> rhs.get();
+    }
+
+    template <class T>
+    constexpr
+    bool operator==(const cloning_ptr<T>& lhs, std::nullptr_t) noexcept
+    {
+        return !lhs;
+    }
+
+    template <class T>
+    requires std::three_way_comparable<typename cloning_ptr<T>::pointer>
+    constexpr
+    std::compare_three_way_result_t<typename cloning_ptr<T>::pointer>
+    operator<=>(const cloning_ptr<T>& lhs, std::nullptr_t) noexcept
+    {
+        using pointer = typename cloning_ptr<T>::pointer;
+        return lhs.get() <=> static_cast<pointer>(nullptr);
     }
 }

--- a/include/sparrow_v01/utils/memory.hpp
+++ b/include/sparrow_v01/utils/memory.hpp
@@ -66,11 +66,15 @@ namespace sparrow
         constexpr cloning_ptr(self_type&& rhs) noexcept = default;
 
         template <class U>
-        requires std::convertible_to<typename cloning_ptr<U>::pointer, pointer>
+        requires std::convertible_to<
+            typename cloning_ptr<U>::pointer,
+            typename cloning_ptr<T>::pointer>
         constexpr cloning_ptr(const cloning_ptr<U>& rhs) noexcept;
 
         template <class U>
-        requires std::convertible_to<typename cloning_ptr<U>::pointer, pointer>
+        requires std::convertible_to<
+            typename cloning_ptr<U>::pointer,
+            typename cloning_ptr<T>::pointer>
         constexpr cloning_ptr(cloning_ptr<U>&& rhs) noexcept;
 
         constexpr self_type& operator=(const self_type&) noexcept;
@@ -78,11 +82,15 @@ namespace sparrow
         constexpr self_type& operator=(std::nullptr_t) noexcept;
 
         template <class U>
-        requires std::convertible_to<typename cloning_ptr<U>::pointer, pointer>
+        requires std::convertible_to<
+            typename cloning_ptr<U>::pointer,
+            typename cloning_ptr<T>::pointer>
         constexpr self_type& operator=(const cloning_ptr<U>& rhs) noexcept;
 
         template <class U>
-        requires std::convertible_to<typename cloning_ptr<U>::pointer, pointer>
+        requires std::convertible_to<
+            typename cloning_ptr<U>::pointer,
+            typename cloning_ptr<T>::pointer>
         constexpr self_type& operator=(cloning_ptr<U>&& rhs) noexcept;
 
         // Modifiers

--- a/include/sparrow_v01/utils/memory.hpp
+++ b/include/sparrow_v01/utils/memory.hpp
@@ -35,7 +35,7 @@ namespace sparrow
     };
 
     /**
-     * @brief smart pointer behaving like a copiable std::unique_ptr.
+     * Smart pointer behaving like a copiable std::unique_ptr.
      * 
      * `cloning_ptr` owns and manages another object through a pointer, like
      * `std::unique_ptr`. The difference with `std::unique_ptr` is that 

--- a/include/sparrow_v01/utils/memory.hpp
+++ b/include/sparrow_v01/utils/memory.hpp
@@ -66,9 +66,7 @@ namespace sparrow
         constexpr cloning_ptr(self_type&& rhs) noexcept = default;
 
         template <class U>
-        requires std::convertible_to<
-            typename cloning_ptr<U>::pointer,
-            typename cloning_ptr<T>::pointer>
+        requires std::convertible_to<U*, T*>
         constexpr cloning_ptr(const cloning_ptr<U>& rhs) noexcept;
 
         template <class U>
@@ -172,7 +170,8 @@ namespace sparrow
 
     template <clonable T>
     template <class U>
-    requires std::convertible_to<typename cloning_ptr<U>::pointer, typename cloning_ptr<T>::pointer>
+    //requires std::convertible_to<typename cloning_ptr<U>::pointer, typename cloning_ptr<T>::pointer>
+    requires std::convertible_to<U*, T*>
     constexpr cloning_ptr<T>::cloning_ptr(const cloning_ptr<U>& rhs) noexcept
         : m_data(rhs->clone())
     {

--- a/test_v01/test_memory.cpp
+++ b/test_v01/test_memory.cpp
@@ -16,10 +16,313 @@
 
 #include "doctest/doctest.h"
 
-TEST_SUITE("memory_v01")
+namespace sparrow::cloning_test
 {
-    TEST_CASE("dummy")
+    class mock_base
     {
-        CHECK_EQ(sparrow::dummy(), 0);
+    public:
+
+        virtual ~mock_base() = default;
+
+        mock_base(mock_base&&) = delete;
+        mock_base& operator=(const mock_base&) = delete;
+        mock_base& operator=(mock_base&&) = delete;
+
+        virtual mock_base* clone() const = 0;
+
+    protected:
+
+        mock_base() = default;
+        mock_base(const mock_base&) = default;
+    };
+
+    class mock_derived : public mock_base
+    {
+    public:
+
+        mock_derived()
+        {
+            ++m_instance_count;
+        }
+
+        virtual ~mock_derived()
+        {
+            --m_instance_count;
+        }
+
+        mock_derived* clone() const override
+        {
+            return new mock_derived(*this);
+        }
+
+        static int instance_count() { return m_instance_count; };
+
+    private:
+
+        mock_derived(const mock_derived&)
+        {
+            ++m_instance_count;
+        }
+
+        static int m_instance_count;
+    };
+
+    int mock_derived::m_instance_count = 0;
+}
+
+namespace sparrow
+{
+    TEST_SUITE("cloning_ptr")
+    {
+        using cloning_test::mock_base;
+        using cloning_test::mock_derived;
+
+        TEST_CASE("constructor")
+        {
+            SUBCASE("default")
+            {
+                cloning_ptr<mock_base> p1;
+                CHECK_EQ(p1.get(), nullptr);
+            }
+
+            SUBCASE("from nullptr")
+            {
+                cloning_ptr<mock_base> p2(nullptr);
+                CHECK_EQ(p2.get(), nullptr);
+            }
+
+            SUBCASE("from allocated pointer")
+            {
+                CHECK_EQ(mock_derived::instance_count(), 0);
+                {
+                    auto d = new mock_derived();
+                    cloning_ptr<mock_base> p(d);
+                    CHECK_EQ(p.get(), d);
+                    CHECK_EQ(mock_derived::instance_count(), 1);
+                }
+                CHECK_EQ(mock_derived::instance_count(), 0);
+            }
+        }
+
+        TEST_CASE("copy constructor")
+        {
+            SUBCASE("default")
+            {
+                cloning_ptr<mock_base> p1(new mock_derived());
+                cloning_ptr<mock_base> p2(p1);
+                CHECK_EQ(mock_derived::instance_count(), 2);
+                CHECK_NE(p1.get(), p2.get());
+            }
+
+            SUBCASE("with conversion")
+            {
+                cloning_ptr<mock_derived> p1(new mock_derived());
+                cloning_ptr<mock_base> p2(p1);
+                CHECK_EQ(mock_derived::instance_count(), 2);
+                CHECK_NE(p1.get(), p2.get());
+            }
+        }
+
+        TEST_CASE("move constructor")
+        {
+            SUBCASE("default")
+            {
+                auto d = new mock_derived();
+                cloning_ptr<mock_base> p1(d);
+                cloning_ptr<mock_base> p2(std::move(p1));
+                CHECK_EQ(mock_derived::instance_count(), 1);
+                CHECK_EQ(p2.get(), d);
+                CHECK_EQ(p1.get(), nullptr);
+            }
+
+            SUBCASE("with conversion")
+            {
+                auto d = new mock_derived();
+                cloning_ptr<mock_derived> p1(d);
+                cloning_ptr<mock_base> p2(std::move(p1));
+                CHECK_EQ(mock_derived::instance_count(), 1);
+                CHECK_EQ(p2.get(), d);
+                CHECK_EQ(p1.get(), nullptr);
+            }
+        }
+
+        TEST_CASE("copy assign")
+        {
+            SUBCASE("default")
+            {
+                auto d = new mock_derived();
+                cloning_ptr<mock_derived> p1(d);
+                cloning_ptr<mock_derived> p2(new mock_derived());
+                CHECK_EQ(mock_derived::instance_count(), 2);
+                p1 = p2;
+                CHECK_EQ(mock_derived::instance_count(), 2);
+                CHECK_NE(p1.get(), p2.get());
+                CHECK_NE(p1.get(), d);
+            }
+
+            SUBCASE("with conversion")
+            {
+                auto d = new mock_derived();
+                cloning_ptr<mock_base> p1(d);
+                cloning_ptr<mock_derived> p2(new mock_derived());
+                CHECK_EQ(mock_derived::instance_count(), 2);
+                p1 = p2;
+                CHECK_EQ(mock_derived::instance_count(), 2);
+                CHECK_NE(p1.get(), p2.get());
+                CHECK_NE(p1.get(), d);
+            }
+
+            SUBCASE("from nullptr")
+            {
+                auto d = new mock_derived();
+                cloning_ptr<mock_derived> p(d);
+                CHECK_EQ(mock_derived::instance_count(), 1);
+                p = nullptr;
+                CHECK_EQ(mock_derived::instance_count(), 0);
+                CHECK_EQ(p.get(), nullptr);
+            }
+        }
+
+        TEST_CASE("move assign")
+        {
+            SUBCASE("default")
+            {
+                auto d = new mock_derived();
+                cloning_ptr<mock_derived> p1(d);
+                cloning_ptr<mock_derived> p2(new mock_derived());
+                CHECK_EQ(mock_derived::instance_count(), 2);
+                p1 = std::move(p2);
+                CHECK_EQ(mock_derived::instance_count(), 1);
+                CHECK_NE(p1.get(), p2.get());
+                CHECK_NE(p1.get(), d);
+                CHECK_EQ(p2.get(), nullptr);
+            }
+
+            SUBCASE("with conversion")
+            {
+                auto d = new mock_derived();
+                cloning_ptr<mock_base> p1(d);
+                cloning_ptr<mock_derived> p2(new mock_derived());
+                CHECK_EQ(mock_derived::instance_count(), 2);
+                p1 = std::move(p2);
+                CHECK_EQ(mock_derived::instance_count(), 1);
+                CHECK_NE(p1.get(), p2.get());
+                CHECK_NE(p1.get(), d);
+                CHECK_EQ(p2.get(), nullptr);
+            }
+        }
+
+        TEST_CASE("release")
+        {
+            auto d = new mock_derived();
+            cloning_ptr<mock_derived> p(d);
+            CHECK_EQ(mock_derived::instance_count(), 1);
+            auto d2 = p.release();
+            CHECK_EQ(mock_derived::instance_count(), 1);
+            CHECK_EQ(d, d2);
+            CHECK_EQ(p.get(), nullptr);
+            delete d2;
+        }
+
+        TEST_CASE("reset")
+        {
+            auto d1 = new mock_derived();
+            auto d2 = new mock_derived();
+            cloning_ptr<mock_derived> p(d1);
+            p.reset(d2);
+            CHECK_EQ(p.get(), d2);
+            CHECK_EQ(mock_derived::instance_count(), 1);
+        }
+
+        TEST_CASE("swap")
+        {
+            auto d1 = new mock_derived();
+            auto d2 = new mock_derived();
+            cloning_ptr<mock_derived> p1(d1);
+            cloning_ptr<mock_derived> p2(d2);
+            
+            SUBCASE("method")
+            {
+                p1.swap(p2);
+                CHECK_EQ(p1.get(), d2);
+                CHECK_EQ(p2.get(), d1);
+            }
+
+            SUBCASE("free function")
+            {
+                swap(p1, p2);
+                CHECK_EQ(p1.get(), d2);
+                CHECK_EQ(p2.get(), d1);
+            }
+        }
+
+        TEST_CASE("operator bool")
+        {
+            cloning_ptr<mock_derived> p;
+            CHECK(!p);
+
+            p.reset(new mock_derived());
+            CHECK(p);
+        }
+
+        TEST_CASE("operator*")
+        {
+            auto d = new mock_derived();
+            cloning_ptr<mock_derived> p(d);
+            auto& unref = *p;
+            CHECK_EQ(&unref, d);
+        }
+
+        TEST_CASE("operator->")
+        {
+            auto d = new mock_derived();
+            cloning_ptr<mock_derived> p(d);
+            auto d2 = p.operator->();
+            CHECK_EQ(d2, d);
+        }
+
+        TEST_CASE("comparison")
+        {
+            auto d1 = new mock_derived();
+            auto d2 = new mock_derived();
+            cloning_ptr<mock_derived> p1(d1);
+            cloning_ptr<mock_derived> p2(d2);
+            cloning_ptr<mock_derived> p3(d1);
+            cloning_ptr<mock_derived> p4;
+
+            SUBCASE("equality")
+            {
+                CHECK(p1 == p3);
+                CHECK(p1 == p1);
+                CHECK(p1 != p2);
+                CHECK(p1 != nullptr);
+                CHECK(p4 == nullptr);
+            }
+            
+            SUBCASE("ordering")
+            {
+                CHECK(p1 <= p1);
+                CHECK(p1 >= p1);
+                if (d1 < d2)
+                {
+                    CHECK(p1 < p2);
+                    CHECK(p1 <= p2);
+                    CHECK(p2 > p1);
+                    CHECK(p2 >= p1);
+                }
+                else
+                {
+                    CHECK(p2 < p1);
+                    CHECK(p2 <= p1);
+                    CHECK(p1 > p2);
+                    CHECK(p1 >= p2);
+                }
+
+                CHECK(p4 <= nullptr);
+                CHECK(p4 >= nullptr);
+                CHECK(p1 >= nullptr);
+            }
+            p3.release();
+        }
     }
 }


### PR DESCRIPTION
Fixes #195 

This is a very basic implementation that can be improved in the future:

- add a deleter template parameter (similar to `std::unique_ptr`)
- add a cloner template parameter with a default value. This sould allow to merge the `cloning_ptr` and the `value_ptr` classes.

Notice that this adds some complexity to the constructors that I did not want to handle at the moment. I'll open an issue when this is merged.