### PR TITLE
Minimal setup for building a shared library

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -65,11 +65,16 @@ jobs:
     - name: Configure using CMake
       run: cmake -G Ninja -Bbuild ${{matrix.sys.config-flags}} -DCMAKE_BUILD_TYPE:STRING=${{matrix.config.name}} -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DUSE_DATE_POLYFILL=${{matrix.sys.date-polyfill}} -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DBUILD_REFACTORING=${{matrix.sys.build_refactoring}}
 
+    - name: Build
+      if: matrix.sys.build_refactoring == 'ON'
+      working-directory: build
+      run: cmake --build . --config ${{matrix.config.name}} --target sparrow --parallel 8
+
     - name: Install
       working-directory: build
       run: cmake --install . --config ${{matrix.config.name}}
 
-    - name: Build
+    - name: Build tests
       working-directory: build
       run: cmake --build . --config ${{matrix.config.name}} --target test_sparrow_lib --parallel 8
 

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -60,11 +60,15 @@ jobs:
     - name: Configure using CMake
       run: cmake -Bbuild -DCMAKE_BUILD_TYPE:STRING=${{matrix.config.name}} -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DBUILD_REFACTORING=ON
 
+    - name: Build
+      working-directory: build
+      run: cmake --build . --config ${{matrix.config.name}} --target sparrow --parallel 8
+
     - name: Install
       working-directory: build
       run: cmake --install . --config ${{matrix.config.name}}
 
-    - name: Build
+    - name: Build tests
       working-directory: build
       run: cmake --build . --config ${{matrix.config.name}} --target test_sparrow_lib --parallel 8
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,11 +65,16 @@ jobs:
     - name: Configure using CMake
       run: cmake -Bbuild -DCMAKE_BUILD_TYPE:STRING=${{matrix.config.name}} -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON  -DUSE_DATE_POLYFILL=${{matrix.sys.date-polyfill}} -DBUILD_REFACTORING=${{matrix.sys.build_refactoring}} -G "${{matrix.build-system}}"
 
+    - name: Build
+      if: matrix.sys.build_refactoring == 'ON'
+      working-directory: build
+      run: cmake --build . --config ${{matrix.config.name}} --target sparrow --parallel 8
+
     - name: Install
       working-directory: build
       run: cmake --install . --config ${{matrix.config.name}}
 
-    - name: Build
+    - name: Build tests
       working-directory: build
       run: cmake --build . --config ${{matrix.config.name}} --target test_sparrow_lib --parallel 8
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ project(sparrow CXX)
 include(CMakeDependentOption)
 
 set(SPARROW_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
+set(SPARROW_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src_v01)
 
 # Versionning
 # ===========
@@ -140,24 +141,53 @@ set(SPARROW_HEADERS
     ${SPARROW_INCLUDE_DIR}/sparrow/details/3rdparty/float16_t.hpp
 )
 
+set(SPARROW_SRC
+    ${SPARROW_SOURCE_DIR}/dummy.cpp
+)
+
 if (BUILD_REFACTORING)
     set(SPARROW_V01_HEADERS
+        ${SPARROW_INCLUDE_DIR}/sparrow_v01/dummy.hpp
         ${SPARROW_INCLUDE_DIR}/sparrow_v01/utils/memory.hpp
     )
     list(APPEND SPARROW_HEADERS ${SPARROW_V01_HEADERS})
 endif ()
 
-add_library(sparrow INTERFACE ${SPARROW_HEADERS})
-
-target_include_directories(sparrow INTERFACE
-    $<BUILD_INTERFACE:${SPARROW_INCLUDE_DIR}>
-    $<INSTALL_INTERFACE:include>)
-
-target_link_libraries(sparrow INTERFACE ${SPARROW_INTERFACE_DEPENDENCIES})
-
-# We do not use non-standard C++
-set_target_properties(sparrow PROPERTIES CMAKE_CXX_EXTENSIONS OFF)
-target_compile_features(sparrow INTERFACE cxx_std_20)
+if (BUILD_REFACTORING)
+    add_library(sparrow SHARED ${SPARROW_HEADERS} ${SPARROW_SRC})
+    # TODO: handle static lib, so name and versionning
+    if (UNIX)
+        set_target_properties(
+            sparrow
+            PROPERTIES
+            PUBLIC_HEADER "${SPARROW_HEADERS}"
+            COMPILE_OPTIONS "-fvisibility=hidden"
+        )
+    else ()
+        set_target_properties(
+            sparrow
+            PROPERTIES
+            PUBLIC_HEADER "${SPARROW_HEADERS}"
+            COMPILE_DEFINITIONS "SPARROW_EXPORTS"
+        )
+    endif ()
+    target_include_directories(sparrow PUBLIC
+        $<BUILD_INTERFACE:${SPARROW_INCLUDE_DIR}>
+        $<INSTALL_INTERFACE:include>)
+    # We do not use non-standard C++
+    set_target_properties(sparrow PROPERTIES CMAKE_CXX_EXTENSIONS OFF)
+    target_compile_features(sparrow PUBLIC cxx_std_20)
+    target_link_libraries(sparrow PUBLIC ${SPARROW_INTERFACE_DEPENDENCIES})
+else ()
+    add_library(sparrow INTERFACE ${SPARROW_HEADERS})
+    target_include_directories(sparrow INTERFACE
+        $<BUILD_INTERFACE:${SPARROW_INCLUDE_DIR}>
+        $<INSTALL_INTERFACE:include>)
+    # We do not use non-standard C++
+    set_target_properties(sparrow PROPERTIES CMAKE_CXX_EXTENSIONS OFF)
+    target_compile_features(sparrow INTERFACE cxx_std_20)
+    target_link_libraries(sparrow INTERFACE ${SPARROW_INTERFACE_DEPENDENCIES})
+endif ()
 
 if (BUILD_TESTS)
     enable_testing()

--- a/include/sparrow/config/config.hpp
+++ b/include/sparrow/config/config.hpp
@@ -26,6 +26,18 @@
 #    define USING_LIBCPP_PRE_17 0
 #endif
 
+#if defined(_WIN32)
+#   if defined(SPARROW_STATIC_LIB)
+#       define SPARROW_API
+#   elif defined(SPARROW_EXPORTS)
+#       define SPARROW_API __declspec(dllexport)
+#   else
+#       define SPARROW_API __declspec(dllimport)
+#   endif
+#else
+#   define SPARROW_API __attribute__((visibility("default")))
+#endif
+
 consteval bool is_apple_compiler()
 {
     return static_cast<bool>(COMPILING_WITH_APPLE_CLANG);

--- a/include/sparrow_v01/dummy.hpp
+++ b/include/sparrow_v01/dummy.hpp
@@ -1,0 +1,20 @@
+// Man Group Operations Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or mplied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "sparrow/config/config.hpp"
+
+namespace sparrow
+{
+    SPARROW_API int dummy();
+}

--- a/src_v01/dummy.cpp
+++ b/src_v01/dummy.cpp
@@ -1,0 +1,24 @@
+// Man Group Operations Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or mplied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "sparrow_v01/dummy.hpp"
+
+namespace sparrow
+{
+    int dummy()
+    {
+        return 0;
+    }
+}
+


### PR DESCRIPTION
Let's handle static build and versionning when the refactoring is done. For now, this handles symbol visibility (defaulted to hidden).