### PR TITLE
Fixed copy semantic for non composed layouts

### DIFF
--- a/src/arrow_array_schema_proxy.cpp
+++ b/src/arrow_array_schema_proxy.cpp
@@ -160,7 +160,7 @@ namespace sparrow
     {
         other.m_array = {};
         other.m_schema = {};
-        other.m_buffers.clear();
+        other.reset();
         update_buffers();
         update_children();
         update_dictionary();

--- a/test/test_dictionary_encoded_array.cpp
+++ b/test/test_dictionary_encoded_array.cpp
@@ -71,6 +71,29 @@ namespace sparrow
             CHECK_NOTHROW(layout_type{make_arrow_proxy()});
         }
 
+        TEST_CASE("copy")
+        {
+            layout_type ar(make_arrow_proxy());
+            layout_type ar2(ar);
+            CHECK_EQ(ar, ar2);
+
+            layout_type ar3(make_arrow_proxy());
+            ar3 = ar;
+            CHECK_EQ(ar, ar3);
+        }
+
+        TEST_CASE("move")
+        {
+            layout_type ar(make_arrow_proxy());
+            layout_type ar2(ar);
+            layout_type ar3(std::move(ar));
+            CHECK_EQ(ar2, ar3);
+
+            layout_type ar4(make_arrow_proxy());
+            ar4 = std::move(ar3);
+            CHECK_EQ(ar2, ar4);
+        }
+
         TEST_CASE("size")
         {
             const layout_type dict(make_arrow_proxy());

--- a/test/test_null_array.cpp
+++ b/test/test_null_array.cpp
@@ -34,6 +34,33 @@ namespace sparrow
             CHECK_EQ(ar.size(), size);
         }
 
+        TEST_CASE("copy")
+        {
+            constexpr std::size_t size = 10u;
+            null_array ar(make_arrow_proxy<null_type>(size));
+            null_array ar2(ar);
+            CHECK_EQ(ar, ar2);
+
+            null_array ar3(make_arrow_proxy<null_type>(size + 2u));
+            CHECK_NE(ar, ar3);
+            ar3 = ar;
+            CHECK_EQ(ar, ar3);
+        }
+
+        TEST_CASE("move")
+        {
+            constexpr std::size_t size = 10u;
+            null_array ar(make_arrow_proxy<null_type>(size));
+            null_array ar2(ar);
+            null_array ar3(std::move(ar));
+            CHECK_EQ(ar3, ar2);
+
+            null_array ar4(make_arrow_proxy<null_type>(size + 3u));
+            CHECK_NE(ar4, ar2);
+            ar4 = std::move(ar3);
+            CHECK_EQ(ar2, ar4);
+        }
+
         TEST_CASE("operator[]")
         {
             constexpr std::size_t size = 10u;

--- a/test/test_primitive_array.cpp
+++ b/test/test_primitive_array.cpp
@@ -35,6 +35,33 @@ namespace sparrow
             CHECK_EQ(ar.size(), size - offset);
         }
 
+        TEST_CASE("copy")
+        {
+            array_test_type ar(make_arrow_proxy<scalar_value_type>(size, offset));
+            array_test_type ar2(ar);
+
+            CHECK_EQ(ar, ar2);
+
+            array_test_type ar3(make_arrow_proxy<scalar_value_type>(size + 3u, offset));
+            CHECK_NE(ar, ar3);
+            ar3 = ar;
+            CHECK_EQ(ar, ar3);
+        }
+
+        TEST_CASE("move")
+        {
+            array_test_type ar(make_arrow_proxy<scalar_value_type>(size, offset));
+            array_test_type ar2(ar);
+
+            array_test_type ar3(std::move(ar));
+            CHECK_EQ(ar2, ar3);
+
+            array_test_type ar4(make_arrow_proxy<scalar_value_type>(size + 3u, offset));
+            CHECK_NE(ar2, ar4);
+            ar4 = std::move(ar2);
+            CHECK_EQ(ar3, ar4);
+        }
+
         TEST_CASE("const operator[]")
         {
             auto pr = make_arrow_proxy<scalar_value_type>(size, offset);

--- a/test/test_variable_size_binary_array.cpp
+++ b/test/test_variable_size_binary_array.cpp
@@ -71,6 +71,29 @@ namespace sparrow
             }
         }
 
+        TEST_CASE_FIXTURE(variable_size_binary_fixture, "copy")
+        {
+            layout_type ar(m_arrow_proxy);
+            layout_type ar2(ar);
+            CHECK_EQ(ar, ar2);
+
+            layout_type ar3(std::move(m_arrow_proxy));
+            ar3 = ar2;
+            CHECK_EQ(ar2, ar3);
+        }
+
+        TEST_CASE_FIXTURE(variable_size_binary_fixture, "move")
+        {
+            layout_type ar(m_arrow_proxy);
+            layout_type ar2(ar);
+            layout_type ar3(std::move(ar));
+            CHECK_EQ(ar2, ar3);
+
+            layout_type ar4(std::move(m_arrow_proxy));
+            ar4 = std::move(ar3);
+            CHECK_EQ(ar2, ar4);
+        }
+
         TEST_CASE_FIXTURE(variable_size_binary_fixture, "size")
         {
             const layout_type array(std::move(m_arrow_proxy));


### PR DESCRIPTION
Fixing the copy semantic of composed layouts requires additional changes in the arrow_proxy structures. Let's do it in a dedicated PR.