### PR TITLE
Cleanup of external_array_data_creation

### DIFF
--- a/test/arrow_array_schema_creation.hpp
+++ b/test/arrow_array_schema_creation.hpp
@@ -27,7 +27,7 @@ inline std::pair<ArrowArray, ArrowSchema> make_external_arrow_schema_and_array()
     std::pair<ArrowArray, ArrowSchema> pair;
     constexpr size_t size = 10;
     constexpr size_t offset = 1;
-    sparrow::test::fill_schema_and_array<uint32_t>(pair.second, pair.first, size, offset, {2, 3});
+    sparrow::test::fill_external_schema_and_array<uint32_t>(pair.second, pair.first, size, offset, {2, 3});
     return pair;
 }
 


### PR DESCRIPTION
The next step will be to move all the `fill_schema_and_array` methods into the different layouts (as factory functions) and remove them from `external_array_data_creation.hpp/.cpp`. Only the `fill_extenral_schema_and_array` function (and it dependencies) should remain in these files.