### PR TITLE
Array dispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ set(SPARROW_HEADERS
     ${SPARROW_INCLUDE_DIR}/sparrow/utils/variant_visitor.hpp
     # ../
     ${SPARROW_INCLUDE_DIR}/sparrow/array.hpp
+    ${SPARROW_INCLUDE_DIR}/sparrow/array_api.hpp
     ${SPARROW_INCLUDE_DIR}/sparrow/array_factory.hpp
     ${SPARROW_INCLUDE_DIR}/sparrow/arrow_array_schema_proxy.hpp
     ${SPARROW_INCLUDE_DIR}/sparrow/c_interface.hpp

--- a/include/sparrow/array.hpp
+++ b/include/sparrow/array.hpp
@@ -14,54 +14,11 @@
 
 #pragma once
 
-#include "sparrow/c_interface.hpp"
-#include "sparrow/config/config.hpp"
-#include "sparrow/layout/array_wrapper.hpp"
-#include "sparrow/layout/nested_value_types.hpp"
-#include "sparrow/types/data_traits.hpp"
+#include "sparrow/array_api.hpp"
+#include "sparrow/layout/dispatch.hpp"
 
 namespace sparrow
 {
-    class array
-    {
-    public:
-
-        using size_type = std::size_t;
-        using value_type = array_traits::value_type;
-        using const_reference = array_traits::const_reference;
- 
-        SPARROW_API array() = default;
-
-        template <layout A>
-        requires (not std::is_lvalue_reference_v<A>)
-        array(A&& a);
-
-        template <layout A>
-        array(A* a);
-
-        template <layout A>
-        array(std::shared_ptr<A> a);
-
-        SPARROW_API array(ArrowArray&& array, ArrowSchema&& schema);
-        SPARROW_API array(ArrowArray&& array, ArrowSchema* schema);
-        SPARROW_API array(ArrowArray* array, ArrowSchema* schema);
-        
-        SPARROW_API bool owns_arrow_array() const;
-        SPARROW_API array& get_arrow_array(ArrowArray*&);
-        SPARROW_API array&& extract_arrow_array(ArrowArray&) &&;
-
-        SPARROW_API bool owns_arrow_schema() const;
-        SPARROW_API array& get_arrow_schema(ArrowSchema*&);
-        SPARROW_API array&& extract_arrow_schema(ArrowSchema&) &&;
-
-        SPARROW_API size_type size() const;
-        SPARROW_API const_reference operator[](size_type) const;
-
-    private:
-
-        cloning_ptr<array_wrapper> p_array = nullptr;
-    };
-
     template <layout A>
     requires (not std::is_lvalue_reference_v<A>)
     array::array(A&& a)
@@ -79,6 +36,12 @@ namespace sparrow
     array::array(std::shared_ptr<A> a)
         : p_array(new array_wrapper_impl<A>(a))
     {
+    }
+
+    template <class F>
+    array::visit_result_t<F> array::visit(F&& func)
+    {
+        return sparrow::visit(std::forward<F>(func), *p_array);
     }
 }
 

--- a/include/sparrow/array_api.hpp
+++ b/include/sparrow/array_api.hpp
@@ -1,0 +1,72 @@
+// Copyright 2024 Man Group Operations Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or mplied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "sparrow/c_interface.hpp"
+#include "sparrow/config/config.hpp"
+#include "sparrow/layout/array_wrapper.hpp"
+#include "sparrow/layout/nested_value_types.hpp"
+#include "sparrow/layout/null_array.hpp"
+#include "sparrow/types/data_traits.hpp"
+
+namespace sparrow
+{
+    class array
+    {
+    public:
+
+        using size_type = std::size_t;
+        using value_type = array_traits::value_type;
+        using const_reference = array_traits::const_reference;
+ 
+        SPARROW_API array() = default;
+
+        template <layout A>
+        requires (not std::is_lvalue_reference_v<A>)
+        array(A&& a);
+
+        template <layout A>
+        array(A* a);
+
+        template <layout A>
+        array(std::shared_ptr<A> a);
+
+        SPARROW_API array(ArrowArray&& array, ArrowSchema&& schema);
+        SPARROW_API array(ArrowArray&& array, ArrowSchema* schema);
+        SPARROW_API array(ArrowArray* array, ArrowSchema* schema);
+        
+        SPARROW_API bool owns_arrow_array() const;
+        SPARROW_API array& get_arrow_array(ArrowArray*&);
+        SPARROW_API array&& extract_arrow_array(ArrowArray&) &&;
+
+        SPARROW_API bool owns_arrow_schema() const;
+        SPARROW_API array& get_arrow_schema(ArrowSchema*&);
+        SPARROW_API array&& extract_arrow_schema(ArrowSchema&) &&;
+
+        SPARROW_API size_type size() const;
+        SPARROW_API const_reference operator[](size_type) const;
+
+        template <class F>
+        using visit_result_t = std::invoke_result_t<F, null_array>;
+        
+        template <class F>
+        visit_result_t<F> visit(F&& func);
+
+    private:
+
+        cloning_ptr<array_wrapper> p_array = nullptr;
+    };
+}
+

--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -222,6 +222,22 @@ namespace sparrow
             }
         }
         TEST_CASE_TEMPLATE_APPLY(extract_arrow_structure_id, testing_types);
+
+        TEST_CASE_TEMPLATE_DEFINE("visit", AR, visit_id)
+        {
+            constexpr size_t offset = 0;
+            constexpr size_t size = 10;
+            using scalar_value_type = typename AR::inner_value_type;
+
+            ArrowSchema sc{};
+            ArrowArray ar{};
+            test::fill_schema_and_array<scalar_value_type>(sc, ar, size, offset, {});
+            array arr(std::move(ar), std::move(sc));
+
+            size_t res = arr.visit([](const auto& impl) { return impl.size(); });
+            CHECK_EQ(res, size);
+        }
+        TEST_CASE_TEMPLATE_APPLY(visit_id, testing_types);
     }
 }
 


### PR DESCRIPTION
Fixes #197.

This is based on #252 to avoid conflicts, therefors you can ignore the first commit when reviewing this PR. Splitting the array header is required because the implementation of `array::visit` includes `layout/dispatch.hpp`, which includes all the layouts, and some of them depends on `array`.