### PR TITLE
Layout hierarchy cleanup

### DIFF
--- a/include/sparrow/layout/array_access.hpp
+++ b/include/sparrow/layout/array_access.hpp
@@ -23,27 +23,27 @@ namespace sparrow::detail
     {
     public:
         template<class ARRAY>
-        static inline const sparrow::arrow_proxy& storage(const ARRAY& array) 
+        static const sparrow::arrow_proxy& get_arrow_proxy(const ARRAY& array) 
         {
-            return array.storage();
+            return array.get_arrow_proxy();
         }
 
         template<class ARRAY>
-        static inline sparrow::arrow_proxy& storage(ARRAY& array)
+        static sparrow::arrow_proxy& get_arrow_proxy(ARRAY& array)
         {
-            return array.storage();
+            return array.get_arrow_proxy();
         }
 
         template<class ARRAY>
         requires(std::is_rvalue_reference_v<ARRAY&&>)
-        static inline sparrow::arrow_proxy extract_arrow_proxy(ARRAY&& array)
+        static sparrow::arrow_proxy extract_arrow_proxy(ARRAY&& array)
         {
             return std::move(array).extract_arrow_proxy();
         }
 
         template<class ARRAY>
         requires(std::is_rvalue_reference_v<ARRAY&&>)
-        static inline auto  extract_array_wrapper(ARRAY&& array)
+        static auto extract_array_wrapper(ARRAY&& array)
         {
             return std::move(array).extract_array_wrapper();
         }

--- a/include/sparrow/layout/array_access.hpp
+++ b/include/sparrow/layout/array_access.hpp
@@ -22,6 +22,7 @@ namespace sparrow::detail
     class array_access
     {
     public:
+
         template<class ARRAY>
         static const sparrow::arrow_proxy& get_arrow_proxy(const ARRAY& array) 
         {

--- a/include/sparrow/layout/array_base.hpp
+++ b/include/sparrow/layout/array_base.hpp
@@ -131,12 +131,11 @@ namespace sparrow
         const_bitmap_iterator bitmap_cend() const;
 
     private:
+
         arrow_proxy m_proxy;
 
         // friend classes
         friend class layout_iterator<iterator_types>;
-        template <class T>
-        friend class array_wrapper_impl;
         friend class detail::array_access;
     };
 

--- a/include/sparrow/layout/array_base.hpp
+++ b/include/sparrow/layout/array_base.hpp
@@ -32,7 +32,7 @@ namespace sparrow
     /**
      * Base class for array_inner_types specialization
      *
-     * It defines common typs used in the array implementation
+     * It defines common types used in the array implementation
      * classes.
      * */
     struct array_inner_types_base
@@ -41,17 +41,25 @@ namespace sparrow
     };
 
     /**
-     * traits class that must be specialized by array
+     * Traits class that must be specialized by array
      * classes inheriting from array_crtp_base.
+     *
+     * @tparam D the class inheriting from array_crtp_base.
      */
     template <class D>
     struct array_inner_types;
 
     /**
-     * Base class defining common interface for arrays.
+     * Base class defining common immutable interface for arrays
+     * with a bitmap.
      *
-     * This class is a CRTP base class that defines and
-     * implements comme interface for arrays with a bitmap.
+     * This class is a CRTP base class that defines and implements
+     * common immutable interface for arrays with a bitmap. These
+     * arrays hold nullable elements.
+     *
+     * @tparam D The derived type, i.e. the inheriting class for which
+     *           array_crtp_base provides the interface.
+     * @see nullable
      */
     template <class D>
     class array_crtp_base : public crtp_base<D>
@@ -146,12 +154,20 @@ namespace sparrow
      * array_crtp_base implementation *
      **********************************/
 
+    /**
+     * Returns the number of elements in the array.
+     */
     template <class D>
     auto array_crtp_base<D>::size() const -> size_type
     {
         return static_cast<size_type>(get_arrow_proxy().length());
     }
 
+    /**
+     * Returns a constant reference to the element at the specified position
+     * in the array.
+     * @param i the index of the element in the array.
+     */
     template <class D>
     auto array_crtp_base<D>::operator[](size_type i) const -> const_reference
     {
@@ -162,36 +178,61 @@ namespace sparrow
         );
     }
 
+    /**
+     * Returns a constant iterator to the first element of the array.
+     */
     template <class D>
     auto array_crtp_base<D>::begin() const -> const_iterator
     {
         return cbegin();
     }
 
+    /**
+     * Returns a constant iterator to the element following the last
+     * element of the array.
+     */
     template <class D>
     auto array_crtp_base<D>::end() const -> const_iterator
     {
         return cend();
     }
 
+    /**
+     * Returns a constant iterator to the first element of the array.
+     * This method ensures that a constant iterator is returned, even
+     * when called on a non-const array.
+     */
     template <class D>
     auto array_crtp_base<D>::cbegin() const -> const_iterator
     {
         return const_iterator(this->derived_cast().value_cbegin(), bitmap_begin());
     }
 
+    /**
+     * Returns a constant iterator to the element following the last
+     * elemnt of the array. This method ensures that a constant iterator 
+     * is returned, even when called on a non-const array.
+     */
     template <class D>
     auto array_crtp_base<D>::cend() const -> const_iterator
     {
         return const_iterator(this->derived_cast().value_cend(), bitmap_end());
     }
 
+    /**
+     * Returns the validity bitmap of the array (i.e. the "has_value" part of the
+     * nullable elements) as a constant range.
+     */
     template <class D>
     auto array_crtp_base<D>::bitmap() const -> const_bitmap_range
     {
         return const_bitmap_range(bitmap_begin(), bitmap_end());
     }
 
+    /**
+     * Returns the raw values of the array (i.e. the "value" part og the nullable
+     * elements) as a constant range.
+     */
     template <class D>
     auto array_crtp_base<D>::values() const -> const_value_range
     {

--- a/include/sparrow/layout/array_wrapper.hpp
+++ b/include/sparrow/layout/array_wrapper.hpp
@@ -18,6 +18,7 @@
 #include <variant>
 
 #include "sparrow/arrow_array_schema_proxy.hpp"
+#include "sparrow/layout/array_access.hpp"
 #include "sparrow/types/data_traits.hpp"
 #include "sparrow/utils/memory.hpp"
 
@@ -250,13 +251,13 @@ namespace sparrow
     template <class T>
     arrow_proxy& array_wrapper_impl<T>::get_arrow_proxy_impl()
     {
-        return p_array->get_arrow_proxy();
+        return detail::array_access::get_arrow_proxy(*p_array);
     }
 
     template <class T>
     const arrow_proxy& array_wrapper_impl<T>::get_arrow_proxy_impl() const
     {
-        return p_array->get_arrow_proxy();
+        return detail::array_access::get_arrow_proxy(*p_array);
     }
 
 
@@ -269,7 +270,7 @@ namespace sparrow
     template <class T>
     auto array_wrapper_impl<T>::extract_arrow_proxy_impl() -> arrow_proxy
     {
-        return std::move(*p_array).extract_arrow_proxy();
+        return detail::array_access::extract_arrow_proxy(std::move(*p_array));
     }
 
     template <class T>

--- a/include/sparrow/layout/dictionary_encoded_array.hpp
+++ b/include/sparrow/layout/dictionary_encoded_array.hpp
@@ -145,9 +145,6 @@ namespace sparrow
         keys_layout m_keys_layout;
         values_layout p_values_layout;
 
-        template <class T>
-        friend class array_wrapper_impl;
-
         friend class detail::array_access;
     };
 

--- a/include/sparrow/layout/mutable_array_base.hpp
+++ b/include/sparrow/layout/mutable_array_base.hpp
@@ -100,8 +100,6 @@ namespace sparrow
         mutable_array_base(mutable_array_base&&) = default;
         mutable_array_base& operator=(mutable_array_base&&) = default;
 
-        using base_type::get_arrow_proxy;
-
         bitmap_iterator bitmap_begin();
         bitmap_iterator bitmap_end();
 
@@ -143,7 +141,7 @@ namespace sparrow
     template <class D>
     auto mutable_array_base<D>::bitmap_begin() -> bitmap_iterator
     {
-        return sparrow::next(this->derived_cast().get_bitmap().begin(), get_arrow_proxy().offset());
+        return sparrow::next(this->derived_cast().get_bitmap().begin(), this->get_arrow_proxy().offset());
     }
 
     template <class D>
@@ -158,7 +156,7 @@ namespace sparrow
         auto& derived = this->derived_cast();
         derived.resize_bitmap(new_length);
         derived.resize_values(new_length, value.get());
-        get_arrow_proxy().set_length(new_length);  // Must be done after resizing the bitmap and values
+        this->get_arrow_proxy().set_length(new_length);  // Must be done after resizing the bitmap and values
         derived.update();
     }
 
@@ -177,7 +175,7 @@ namespace sparrow
         auto& derived = this->derived_cast();
         derived.insert_bitmap(sparrow::next(this->bitmap_cbegin(), distance), value.has_value(), count);
         derived.insert_value(sparrow::next(derived.value_cbegin(), distance), value.get(), count);
-        get_arrow_proxy().set_length(this->size() + count);  // Must be done after resizing the bitmap and values
+        this->get_arrow_proxy().set_length(this->size() + count);  // Must be done after resizing the bitmap and values
         derived.update();
         return sparrow::next(begin(), distance);
     }
@@ -223,8 +221,9 @@ namespace sparrow
             value_range.end()
         );
         const difference_type count = std::distance(first, last);
-        get_arrow_proxy().set_length(this->size() + static_cast<size_t>(count));  // Must be done after modifying
-                                                                              // the bitmap and values
+        // The following must be done after modifying the bitmap and values
+        this->get_arrow_proxy().set_length(this->size() + static_cast<size_t>(count));
+
         derived.update();
         return sparrow::next(begin(), distance);
     }
@@ -259,7 +258,7 @@ namespace sparrow
         auto& derived = this->derived_cast();
         derived.erase_bitmap(sparrow::next(this->bitmap_cbegin(), first_index), count);
         derived.erase_values(sparrow::next(derived.value_cbegin(), first_index), count);
-        get_arrow_proxy().set_length(this->size() - count);  // Must be done after modifying the bitmap and values
+        this->get_arrow_proxy().set_length(this->size() - count);  // Must be done after modifying the bitmap and values
         derived.update();
         return sparrow::next(begin(), first_index);
     }

--- a/include/sparrow/layout/null_array.hpp
+++ b/include/sparrow/layout/null_array.hpp
@@ -106,11 +106,7 @@ namespace sparrow
         [[nodiscard]] arrow_proxy& get_arrow_proxy();
         [[nodiscard]] const arrow_proxy& get_arrow_proxy() const;
 
-
         arrow_proxy m_proxy;
-
-        template <class T>
-        friend class array_wrapper_impl;
 
         friend class detail::array_access;
     };

--- a/include/sparrow/layout/primitive_array.hpp
+++ b/include/sparrow/layout/primitive_array.hpp
@@ -95,6 +95,8 @@ namespace sparrow
         primitive_array(Args&& ... args) : base_type(create_proxy(std::forward<Args>(args) ...))
         {}
 
+    private:
+
         pointer data();
         const_pointer data() const;
 
@@ -106,8 +108,6 @@ namespace sparrow
 
         const_value_iterator value_cbegin() const;
         const_value_iterator value_cend() const;
-
-    private:
 
         static arrow_proxy create_proxy(size_type n);
 
@@ -137,7 +137,6 @@ namespace sparrow
             std::ranges::range_value_t<R>, nullable<T>>
         static arrow_proxy create_proxy(R&&);
 
-
         // Modifiers
 
         void resize_values(size_type new_length, inner_value_type value);
@@ -156,6 +155,7 @@ namespace sparrow
         friend class run_end_encoded_array;
         friend base_type;
         friend base_type::base_type;
+        friend base_type::base_type::base_type;
     };
 
     /**********************************

--- a/include/sparrow/layout/primitive_array.hpp
+++ b/include/sparrow/layout/primitive_array.hpp
@@ -92,7 +92,12 @@ namespace sparrow
 
         template <class ... Args>
         requires(mpl::excludes_copy_and_move_ctor_v<primitive_array<T>, Args...>)
-        primitive_array(Args&& ... args) : base_type(create_proxy(std::forward<Args>(args) ...))
+        explicit primitive_array(Args&& ... args)
+            : base_type(create_proxy(std::forward<Args>(args) ...))
+        {}
+
+        primitive_array(std::initializer_list<inner_value_type> init)
+            : base_type(create_proxy(init))
         {}
 
     private:

--- a/include/sparrow/layout/run_end_encoded_layout/run_end_encoded_array.hpp
+++ b/include/sparrow/layout/run_end_encoded_layout/run_end_encoded_array.hpp
@@ -93,8 +93,6 @@ namespace sparrow
         // friend classes
         friend class run_encoded_array_iterator<false>;
         friend class run_encoded_array_iterator<true>;
-        template <class T>
-        friend class array_wrapper_impl;
         friend class detail::array_access;
     };
 

--- a/include/sparrow/layout/union_array.hpp
+++ b/include/sparrow/layout/union_array.hpp
@@ -107,8 +107,6 @@ namespace sparrow
         // map from type-id to child-index
         std::array<std::uint8_t, 256> m_type_id_map;
 
-        template <class T>
-        friend class array_wrapper_impl;
         friend class detail::array_access;
     };  
 

--- a/include/sparrow/layout/variable_size_binary_array.hpp
+++ b/include/sparrow/layout/variable_size_binary_array.hpp
@@ -224,9 +224,6 @@ namespace sparrow
 
         explicit variable_size_binary_array(arrow_proxy);
 
-        using base_type::size;
-        using base_type::get_arrow_proxy;
-
     private:
 
         static constexpr size_t OFFSET_BUFFER_INDEX = 1;
@@ -445,7 +442,7 @@ namespace sparrow
     variable_size_binary_array<T, CR, OT>::variable_size_binary_array(arrow_proxy proxy)
         : base_type(std::move(proxy))
     {
-        const auto type = get_arrow_proxy().data_type();
+        const auto type = this->get_arrow_proxy().data_type();
         SPARROW_ASSERT_TRUE(type == data_type::STRING || type == data_type::BINARY);  // TODO: Add
                                                                                       // data_type::LARGE_STRING
                                                                                       // and
@@ -472,8 +469,8 @@ namespace sparrow
     template <std::ranges::sized_range T, class CR, layout_offset OT>
     auto variable_size_binary_array<T, CR, OT>::data(size_type i) const -> const_data_iterator
     {
-        SPARROW_ASSERT_FALSE(get_arrow_proxy().buffers()[DATA_BUFFER_INDEX].size() == 0u);
-        return get_arrow_proxy().buffers()[DATA_BUFFER_INDEX].template data<const data_value_type>() + i;
+        SPARROW_ASSERT_FALSE(this->get_arrow_proxy().buffers()[DATA_BUFFER_INDEX].size() == 0u);
+        return this->get_arrow_proxy().buffers()[DATA_BUFFER_INDEX].template data<const data_value_type>() + i;
     }
 
     // template <std::ranges::sized_range T, class CR, layout_offset OT>
@@ -524,9 +521,9 @@ namespace sparrow
     template <std::ranges::sized_range T, class CR, layout_offset OT>
     auto variable_size_binary_array<T, CR, OT>::offset(size_type i) const -> const_offset_iterator
     {
-        SPARROW_ASSERT_TRUE(i < size() + get_arrow_proxy().offset());
-        return get_arrow_proxy().buffers()[OFFSET_BUFFER_INDEX].template data<OT>()
-               + static_cast<size_type>(get_arrow_proxy().offset()) + i;
+        SPARROW_ASSERT_TRUE(i < this->size() + this->get_arrow_proxy().offset());
+        return this->get_arrow_proxy().buffers()[OFFSET_BUFFER_INDEX].template data<OT>()
+               + static_cast<size_type>(this->get_arrow_proxy().offset()) + i;
     }
 
     // template <std::ranges::sized_range T, class CR, layout_offset OT>
@@ -540,7 +537,7 @@ namespace sparrow
     template <std::ranges::sized_range T, class CR, layout_offset OT>
     auto variable_size_binary_array<T, CR, OT>::value(size_type i) const -> inner_const_reference
     {
-        SPARROW_ASSERT_TRUE(i < size());
+        SPARROW_ASSERT_TRUE(i < this->size());
         const OT offset_begin = *offset(i);
         SPARROW_ASSERT_TRUE(offset_begin >= 0);
         const OT offset_end = *offset(i + 1);
@@ -571,6 +568,6 @@ namespace sparrow
     template <std::ranges::sized_range T, class CR, layout_offset OT>
     auto variable_size_binary_array<T, CR, OT>::value_cend() const -> const_value_iterator
     {
-        return sparrow::next(value_cbegin(), size());
+        return sparrow::next(value_cbegin(), this->size());
     }
 }

--- a/include/sparrow/utils/crtp_base.hpp
+++ b/include/sparrow/utils/crtp_base.hpp
@@ -14,27 +14,35 @@
 
 #pragma once
 
-
 namespace sparrow
 {
-    template<class DERIVED>
+    /**
+     * Base class for CRTP base classes.
+     *
+     * This class provides convenient derived cast
+     * methods for CRTP base classes.
+     *
+     * @tparam D The derived type.
+     */
+    template<class D>
     class crtp_base
     {
     protected:
-        using derived_type = DERIVED;
+
+        using derived_type = D;
 
         derived_type& derived_cast();
         const derived_type& derived_cast() const;
     };
 
-    template<class DERIVED>
-    auto crtp_base<DERIVED>::derived_cast() -> derived_type&
+    template<class D>
+    auto crtp_base<D>::derived_cast() -> derived_type&
     {
         return static_cast<derived_type&>(*this);
     }
 
-    template<class DERIVED>
-    auto crtp_base<DERIVED>::derived_cast() const -> const derived_type&
+    template<class D>
+    auto crtp_base<D>::derived_cast() const -> const derived_type&
     {
         return static_cast<const derived_type&>(*this);
     }

--- a/test/test_primitive_array.cpp
+++ b/test/test_primitive_array.cpp
@@ -611,8 +611,9 @@ namespace sparrow
                 CHECK_EQ(ar[2].get(), values[3]);
             }
         }
+        TEST_CASE_TEMPLATE_APPLY(primitive_array_id, testing_types);
 
-        TEST_CASE_TEMPLATE("convenience_constructors", T, std::uint8_t) 
+        TEST_CASE_TEMPLATE_DEFINE("convenience_constructors", T, convenience_constructors_id)
         {
             using inner_value_type = T;
 
@@ -649,9 +650,15 @@ namespace sparrow
                 CHECK_EQ(arr[1].value(), data[1]);
                 CHECK_EQ(arr[3].value(), data[3]);
             }
-            
+            SUBCASE("initializer list")
+            {
+                primitive_array<T> arr = { T(0), T(1), T(2) };
+                CHECK_EQ(arr[0].value(), T(0));
+                CHECK_EQ(arr[1].value(), T(1));
+                CHECK_EQ(arr[2].value(), T(2));
+            }
         }
-        TEST_CASE_TEMPLATE_APPLY(primitive_array_id, testing_types);
+        TEST_CASE_TEMPLATE_APPLY(convenience_constructors_id, testing_types);
 
         TEST_CASE("convenience_constructors_from_iota")
         {   


### PR DESCRIPTION
- Removed using declaration importing CRTP base class methods to avoid typing `this->`
- USed array_access for every access to the layouts proxy
- Removed useless friendships
- Moved almost of methods of primitive_arrya to the private section
- Made primitive_array constructor explicit except for the one accepting an `initializer_list`