### PR TITLE
Workaround MSVC warning treated as error (C4459)

### DIFF
--- a/include/sparrow/layout/dictionary_encoded_array.hpp
+++ b/include/sparrow/layout/dictionary_encoded_array.hpp
@@ -40,11 +40,11 @@ namespace sparrow
 
         constexpr layout_element_functor() = default;
 
-        constexpr explicit layout_element_functor(storage_type layout)
-            : p_layout(layout)
+        constexpr explicit layout_element_functor(storage_type layout_)
+            : p_layout(layout_)
         {
         }
-        
+
         return_type operator()(std::size_t i) const
         {
             return p_layout->operator[](i);
@@ -208,7 +208,7 @@ namespace sparrow
     {
         return m_proxy.length();
     }
-    
+
     template <std::integral IT>
     auto dictionary_encoded_array<IT>::operator[](size_type i) const -> const_reference
     {
@@ -229,7 +229,7 @@ namespace sparrow
     {
         return iterator(functor_type(this), 0u);
     }
-    
+
     template <std::integral IT>
     auto dictionary_encoded_array<IT>::end() -> iterator
     {
@@ -241,7 +241,7 @@ namespace sparrow
     {
         return cbegin();
     }
-    
+
     template <std::integral IT>
     auto dictionary_encoded_array<IT>::end() const -> const_iterator
     {
@@ -270,7 +270,7 @@ namespace sparrow
     /*template <std::integral IT>
     auto dictionary_encoded_array<IT>::dummy_inner_const_reference() const -> inner_const_reference
     {
-        static const inner_const_reference instance = 
+        static const inner_const_reference instance =
             std::visit([](const auto& val) -> inner_const_reference { return val; }, dummy_inner_value());
         return instance;
     }*/
@@ -278,7 +278,7 @@ namespace sparrow
     template <std::integral IT>
     auto dictionary_encoded_array<IT>::dummy_const_reference() const -> const_reference
     {
-        static const const_reference instance = 
+        static const const_reference instance =
             std::visit([](const auto& val) -> const_reference {
                 using inner_ref = typename arrow_traits<std::decay_t<decltype(val)>>::const_reference;
                 return nullable<inner_ref>(inner_ref(val), false);
@@ -296,7 +296,7 @@ namespace sparrow
         arrow_proxy ar_dictionary{&(dictionary->array()), &(dictionary->schema())};
         return array_factory(std::move(ar_dictionary));
     }
-    
+
     template <std::integral IT>
     auto dictionary_encoded_array<IT>::create_keys_layout(arrow_proxy& proxy) -> keys_layout
     {

--- a/include/sparrow/layout/layout_utils.hpp
+++ b/include/sparrow/layout/layout_utils.hpp
@@ -31,8 +31,8 @@ namespace sparrow::detail
         using value_type = VALUE_TYPE;
         using layout_type = LAYOUT_TYPE;
 
-        constexpr explicit layout_value_functor(layout_type* layout = nullptr)
-            : p_layout(layout)
+        constexpr explicit layout_value_functor(layout_type* layout_ = nullptr)
+            : p_layout(layout_)
         {
         }
 
@@ -59,8 +59,8 @@ namespace sparrow::detail
         using value_type = VALUE_TYPE;
         using layout_type = LAYOUT_TYPE;
 
-        constexpr explicit layout_bracket_functor(layout_type* layout = nullptr)
-            : p_layout(layout)
+        constexpr explicit layout_bracket_functor(layout_type* layout_ = nullptr)
+            : p_layout(layout_)
         {
         }
 
@@ -77,7 +77,7 @@ namespace sparrow::detail
 
 
     template<class OFFSET_TYPE>
-    concept offset_type = std::is_same<std::remove_const_t<OFFSET_TYPE>, std::uint32_t>::value || 
+    concept offset_type = std::is_same<std::remove_const_t<OFFSET_TYPE>, std::uint32_t>::value ||
                             std::is_same<std::remove_const_t<OFFSET_TYPE>, std::uint64_t>::value;
 
     template<offset_type OFFSET_TYPE, std::ranges::range SIZES_RANGE>
@@ -85,7 +85,7 @@ namespace sparrow::detail
     sparrow::u8_buffer<OFFSET_TYPE> offset_buffer_from_sizes(SIZES_RANGE && sizes)
     {
         sparrow::u8_buffer<OFFSET_TYPE> buffer(std::ranges::size(sizes) + 1);
-        
+
         OFFSET_TYPE offset = 0;
         auto it = buffer.begin();
         for(auto size : sizes)
@@ -96,6 +96,6 @@ namespace sparrow::detail
         }
         *it = offset;
         return buffer;
-    } 
+    }
 
 } // namespace sparrow


### PR DESCRIPTION
See: https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4459?view=msvc-170 For some reason this warning treated as error is not stopping the CI for Windows/msvc build. I didn't find the reason, but I needed this change to be able to build `main` locally.

This solution is the simplest but another more general solution would be to move sparrow concepts in their own namespace (`concepts::layout` for example).
Personally I dont mind local shadowing of names so deactivating this warning would work for me too.