### PR TITLE
fix format

### DIFF
--- a/include/sparrow/utils/large_int.hpp
+++ b/include/sparrow/utils/large_int.hpp
@@ -119,6 +119,8 @@ namespace sparrow
 
 #if defined(__cpp_lib_format)
 
+#    if defined(SPARROW_USE_LARGE_INT_PLACEHOLDERS)
+
 template <>
 struct std::formatter<sparrow::int128_t>
 {
@@ -129,9 +131,11 @@ struct std::formatter<sparrow::int128_t>
 
     auto format(const sparrow::int128_t&, std::format_context& ctx) const
     {
-        return std::format_to(ctx.out(), "{}", "Decimal int128_t TODO");
+        return std::format_to(ctx.out(), "{}", "Integer int128_t TODO");
     }
 };
+
+#    endif
 
 template <>
 struct std::formatter<sparrow::int256_t>
@@ -143,7 +147,7 @@ struct std::formatter<sparrow::int256_t>
 
     auto format(const sparrow::int256_t&, std::format_context& ctx) const
     {
-        return std::format_to(ctx.out(), "{}", "Decimal int256_t TODO");
+        return std::format_to(ctx.out(), "{}", "Integer int256_t TODO");
     }
 };
 


### PR DESCRIPTION
Issue on mac-os:
```
/Users/thorstenbeier/src/sparrow/include/sparrow/utils/large_int.hpp:125:13: error: explicit specialization of 'std::formatter<__int128>' after instantiation
  125 | struct std::formatter<sparrow::int128_t>
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/thorstenbeier/micromamba/envs/sparrow/bin/../include/c++/v1/__format/format_functions.h:181:26: note: implicit instantiation first required here
  181 |   formatter<_Tp, _CharT> __formatter;
```

when `_int128` is used, `sparrow::int128_t` will be a typedef to `_int128`. For for `_int128` the std::formater is already defined / specialized.

