### PR TITLE
U8 buffer

### DIFF
--- a/include/sparrow/u8_buffer.hpp
+++ b/include/sparrow/u8_buffer.hpp
@@ -139,6 +139,12 @@ namespace sparrow
          * Destructor.
          */
         ~u8_buffer() = default;
+         /**
+         * Constructs a buffer with \c n uninitialized elements.
+         *
+         * @param n Number of elements.
+         */
+        constexpr explicit u8_buffer(std::size_t n);
 
         /**
          * Constructs a buffer with \c n elements, each initialized to \c val.
@@ -146,7 +152,7 @@ namespace sparrow
          * @param n Number of elements.
          * @param val Value to initialize the elements with.
          */
-        constexpr u8_buffer(std::size_t n, const T& val = T{});
+        constexpr u8_buffer(std::size_t n, const T& val);
 
         /**
          * Constructs a buffer with the elements of the range \c range.
@@ -197,9 +203,15 @@ namespace sparrow
     }
 
     template <class T>
-    constexpr u8_buffer<T>::u8_buffer(std::size_t n, const T& val)
+    constexpr u8_buffer<T>::u8_buffer(std::size_t n)
         : holder_type{n * sizeof(T)}
         , buffer_adaptor_type(holder_type::value)
+    {
+    }
+        
+    template <class T>
+    constexpr u8_buffer<T>::u8_buffer(std::size_t n, const T& val)
+        : u8_buffer(n)
     {
         std::fill(this->begin(), this->end(), val);
     }
@@ -209,16 +221,14 @@ namespace sparrow
         requires(!std::same_as<u8_buffer<T>, std::decay_t<R>>
                  && std::convertible_to<std::ranges::range_value_t<R>, T>)
     constexpr u8_buffer<T>::u8_buffer(R&& range)
-        : holder_type{range_size(range) * sizeof(T)}
-        , buffer_adaptor_type(holder_type::value)
+        : u8_buffer(range_size(range))
     {
         sparrow::ranges::copy(range, this->begin());
     }
 
     template <class T>
     constexpr u8_buffer<T>::u8_buffer(std::initializer_list<T> ilist)
-        : holder_type{ilist.size() * sizeof(T)}
-        , buffer_adaptor_type(holder_type::value)
+        : u8_buffer(ilist.size())
     {
         std::copy(ilist.begin(), ilist.end(), this->begin());
     }

--- a/include/sparrow/u8_buffer.hpp
+++ b/include/sparrow/u8_buffer.hpp
@@ -140,7 +140,7 @@ namespace sparrow
          * Destructor.
          */
         ~u8_buffer() = default;
-         /**
+        /**
          * Constructs a buffer with \c n uninitialized elements.
          *
          * @param n Number of elements.
@@ -212,7 +212,7 @@ namespace sparrow
         , buffer_adaptor_type(holder_type::value)
     {
     }
-        
+
     template <class T>
     constexpr u8_buffer<T>::u8_buffer(std::size_t n, const T& val)
         : u8_buffer(n)
@@ -222,8 +222,9 @@ namespace sparrow
 
     template <class T>
     template <std::ranges::input_range R>
-        requires(!std::same_as<u8_buffer<T>, std::decay_t<R>>
-                 && std::convertible_to<std::ranges::range_value_t<R>, T>)
+        requires(
+            !std::same_as<u8_buffer<T>, std::decay_t<R>> && std::convertible_to<std::ranges::range_value_t<R>, T>
+        )
     constexpr u8_buffer<T>::u8_buffer(R&& range)
         : u8_buffer(range_size(range))
     {

--- a/include/sparrow/u8_buffer.hpp
+++ b/include/sparrow/u8_buffer.hpp
@@ -179,6 +179,9 @@ namespace sparrow
 
         /**
          * Constructs a buffer by taking ownership of the storage pointed to by \c data_ptr.
+         * `data_ptr` must have been allocated with the same allocator used by u8_buffer.
+         * Especially, one should not mixed operator new[] and std::allocator, as this
+         * later is not guaranteed to free the memory with a call to operator delete[] only.
          *
          * @tparam A The allocator type.
          * @param data_ptr Pointer to the storage.

--- a/include/sparrow/u8_buffer.hpp
+++ b/include/sparrow/u8_buffer.hpp
@@ -110,6 +110,7 @@ namespace sparrow
         using holder_type = detail::holder<buffer<std::uint8_t>>;
         using buffer_adaptor_type = buffer_adaptor<T, buffer<std::uint8_t>&>;
         using holder_type::extract_storage;
+        using default_allocator_type = std::allocator<std::uint8_t>;
 
         /**
          * Move constructor.
@@ -184,7 +185,7 @@ namespace sparrow
          * @param count Number of elements in the storage.
          * @param a The allocator to use.
          */
-        template <allocator A = std::allocator<std::uint8_t>>
+        template <allocator A = default_allocator_type>
         constexpr u8_buffer(T* data_ptr, std::size_t count, const A& a = A());
     };
 


### PR DESCRIPTION
This PR "fixes" two issues:
- Allows to allocate an uninitialized u8_buffer, making it easier to implement deserialization in sparrow-ipc (instead of allocating a raw_buffer, one can directly allocate a u8_buffer)
- Provides the default allocator as an inner typedef, so that it's easier for users to allocate the raw buffer with the same allocator as that used by u8_buffer by default. *Users should not pass raw buffer allocated with operator new[] without passing a dedicated allocator performing the deletion with operator delete[]. std::allocator is not guaranteed to used operator delete[] only*