### PR TITLE
Manually define FE_XX macros for emscripten build

### DIFF
--- a/include/sparrow/details/3rdparty/float16_t.hpp
+++ b/include/sparrow/details/3rdparty/float16_t.hpp
@@ -200,6 +200,30 @@
 	#define FE_ALL_EXCEPT	(FE_INVALID|FE_DIVBYZERO|FE_OVERFLOW|FE_UNDERFLOW|FE_INEXACT)
 #endif
 
+#ifdef __EMSCRIPTEN__
+// Emscripten defines FE_ALL_EXCEPT as 0, which causes the fallback above to be skipped,
+// but does not define the individual FE_* macros. So we patch them manually here.
+
+#ifndef FE_INEXACT
+#define FE_INEXACT 0x02
+#endif
+#ifndef FE_INVALID
+#define FE_INVALID 0x04
+#endif
+#ifndef FE_OVERFLOW
+#define FE_OVERFLOW 0x08
+#endif
+#ifndef FE_UNDERFLOW
+#define FE_UNDERFLOW 0x10
+#endif
+#ifndef FE_DIVBYZERO
+#define FE_DIVBYZERO 0x01
+#endif
+#ifndef FE_ALL_EXCEPT
+#define FE_ALL_EXCEPT (FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW | FE_UNDERFLOW | FE_INEXACT)
+#endif
+#endif // __EMSCRIPTEN__
+
 
 /// Main namespace for half-precision functionality.
 /// This namespace contains all the functionality provided by the library.


### PR DESCRIPTION
Hi, 

I shall be trying to address the emscripten build of sparrow through a series of 2-3 PRs. We should then be able to use it directly through xeus-cpp-lite. Once done, I shall also add a CI for emscripten.

This is the first fix required for it to build correctly.

This patch defines the FE_INEXACT, FE_INVALID, and related floating-point exception macros when building with Emscripten, since its <fenv.h> header stubs out FE_ALL_EXCEPT but omits the individual FE_* macros.

Check build error here : https://github.com/emscripten-forge/recipes/actions/runs/16363899873/job/46236883737

This was added as a patch on emscripten-forge when 1.0 was released.

