### PR TITLE
Loading sparrow's shared build for emscripten use case

### DIFF
--- a/environment-wasm-host.yml
+++ b/environment-wasm-host.yml
@@ -1,0 +1,5 @@
+name: sparrow-wasm-host
+channels:
+  - https://repo.prefix.dev/emscripten-forge-dev
+dependencies:
+  - howardhinnant_date

--- a/include/sparrow/config/config.hpp
+++ b/include/sparrow/config/config.hpp
@@ -63,3 +63,21 @@
 #else
 #    define SPARROW_CONSTEXPR_CLANG constexpr
 #endif
+
+#if defined(__EMSCRIPTEN__) && defined(__CLANG_REPL__)
+#    include <clang/Interpreter/CppInterOp.h>
+
+#    ifndef SPARROW_USE_DATE_POLYFILL
+#        define SPARROW_USE_DATE_POLYFILL 1
+#    endif
+
+#    ifndef HALF_ERRHANDLING_THROWS
+#        define HALF_ERRHANDLING_THROWS 1
+#    endif
+
+static bool _sparrow_loaded = []()
+{
+    Cpp::LoadLibrary("/lib/libsparrow.so", false);
+    return true;
+}();
+#endif


### PR DESCRIPTION
This should get us started with using sparrow directly with xeus-cpp-lite. We could possibly have an example notebook possibly covering all of sparrow's docs.

<img width="896" height="756" alt="image" src="https://github.com/user-attachments/assets/112d1200-1d20-4d52-a916-d85db0ed7c08" />

Once this goes in and there's a release anytime soon, we could just take a xeus-cpp-lite instance and fetch sparrow through 
`%mamba install sparrow` and put it to use !