### PR TITLE
Add html anchor

### DIFF
--- a/docs/source/record_batch.md
+++ b/docs/source/record_batch.md
@@ -1,4 +1,4 @@
-# Record Batch
+# Record Batch      {#record_batch}
 
 ## Overview
 


### PR DESCRIPTION
The landing page lacks a proper link for 'record_batch' in its main block:

<img width="919" height="568" alt="image" src="https://github.com/user-attachments/assets/aa84667c-1749-407f-8828-02c62af340e1" />

though it appears in the navigation.  All other sections have an anchor, but record_batch.md is missing one so the PR suggests to add it.