### PR TITLE
Adjust instantiation order to match declaration

### DIFF
--- a/include/sparrow/arrow_interface/arrow_array_schema_proxy.hpp
+++ b/include/sparrow/arrow_interface/arrow_array_schema_proxy.hpp
@@ -969,11 +969,11 @@ namespace sparrow
         std::vector<sparrow::buffer_view<uint8_t>> m_buffers;
         std::vector<arrow_proxy> m_children;
         std::unique_ptr<arrow_proxy> m_dictionary;
-        bool m_schema_is_immutable = false;
         bool m_array_is_immutable = false;
+        bool m_schema_is_immutable = false;
+        bool m_is_dictionary_immutable = false;
         std::vector<bool> m_children_array_immutable;
         std::vector<bool> m_children_schema_immutable;
-        bool m_is_dictionary_immutable = false;
 
         struct impl_tag
         {


### PR DESCRIPTION
In another project with `sparrow` vendore, the compiler complains about the instantation order.  This short PR ensure it matches the declaration 

https://github.com/man-group/sparrow/blob/b1b8ae12391bce18bdecb9261c0ea9de7dd3ae30/src/arrow_interface/arrow_array_schema_proxy.cpp#L213-L215

so that the warning goes away.