### PR TITLE
Enable more tests for the emscripten build

### DIFF
--- a/environment-wasm-host.yml
+++ b/environment-wasm-host.yml
@@ -4,4 +4,3 @@ channels:
 dependencies:
   - howardhinnant_date
   - doctest
-  - emscripten-abi==4.0.9

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,8 +50,10 @@ set(SPARROW_TESTS_SOURCES
     test_arrow_array.cpp
     test_arrow_schema.cpp
     test_bit.cpp
+    test_binary_array.cpp
     test_buffer_adaptor.cpp
     test_buffer.cpp
+    test_builder.cpp
     test_builder_dict_encoded.cpp
     test_builder_run_end_encoded.cpp
     test_builder_utils.cpp
@@ -87,6 +89,7 @@ set(SPARROW_TESTS_SOURCES
     test_record_batch.cpp
     test_repeat_container.cpp
     test_run_end_encoded_array.cpp
+    test_string_array.cpp
     test_struct_array.cpp
     test_time_array.cpp
     test_timestamp_without_timezone_array.cpp
@@ -101,9 +104,6 @@ set(SPARROW_TESTS_SOURCES
 
 if(NOT EMSCRIPTEN)
   list(APPEND SPARROW_TESTS_SOURCES
-    test_binary_array.cpp
-    test_builder.cpp
-    test_string_array.cpp
     test_timestamp_array.cpp
   )
 endif()

--- a/test/test_binary_array.cpp
+++ b/test/test_binary_array.cpp
@@ -110,12 +110,12 @@ namespace sparrow
         {
             SUBCASE("copy arrow_proxy")
             {
-                CHECK_NOTHROW(layout_type(m_arrow_proxy));
+                CHECK_NOTHROW(layout_type{m_arrow_proxy});
             }
 
             SUBCASE("move arrow_proxy")
             {
-                CHECK_NOTHROW(layout_type(std::move(m_arrow_proxy)));
+                CHECK_NOTHROW(layout_type{std::move(m_arrow_proxy)});
             }
         }
 

--- a/test/test_builder.cpp
+++ b/test/test_builder.cpp
@@ -61,6 +61,7 @@ namespace sparrow
             }
         }
 
+#ifndef EMSCRIPTEN
         TEST_CASE("timestamp-layout")
         {
             SUBCASE("timestamp_milliseconds_array")
@@ -76,6 +77,7 @@ namespace sparrow
                 REQUIRE_EQ(arr.size(), 3);
             }
         }
+#endif
 
         using duration_testing_types = mpl::rename<duration_types_t, std::tuple>;
 

--- a/test/test_string_array.cpp
+++ b/test/test_string_array.cpp
@@ -102,12 +102,12 @@ namespace sparrow
         {
             SUBCASE("copy arrow_proxy")
             {
-                CHECK_NOTHROW(layout_type(m_arrow_proxy));
+                CHECK_NOTHROW(layout_type{m_arrow_proxy});
             }
 
             SUBCASE("move arrow_proxy")
             {
-                CHECK_NOTHROW(layout_type(std::move(m_arrow_proxy)));
+                CHECK_NOTHROW(layout_type{std::move(m_arrow_proxy)});
             }
 
             SUBCASE("from u8_buffer, offset_buffer_type, validity_bitmap_input, name and metadata")


### PR DESCRIPTION
Most of the symbol resolution errors we had last time with these tests are now resolved after the migration to 4-x.

