### PR TITLE
fix(arrow_interface): replace brace-init array-new with explicit assignment for MSVC compat

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,14 +39,12 @@ jobs:
         - { name: Debug }
         - { name: Release }
         build-system:
-        - { name: "Visual Studio 17 2022" }
-        - { name: "Visual Studio 18 2026" }
-        - { name: "Ninja" }
-        exclude:
+        - {name: "Ninja"}
+        include:
         - runs-on: windows-latest
-          build-system: { name: "Visual Studio 18 2026" }
+          build-system: {name: "Visual Studio 17 2022"}
         - runs-on: windows-2025-vs2026
-          build-system: { name: "Visual Studio 17 2022" }
+          build-system: {name: "Visual Studio 18 2026"}
 
     steps:
     - name: Setup MSVC (only for non-VS buildsystems)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,9 +42,9 @@ jobs:
         - {name: "Ninja"}
         include:
         - runs-on: windows-latest
-          build-system: {name: "Visual Studio 17 2022"}
+          build-system: {name: "Visual Studio 17 2022", vs-version-range: "[17.0,18.0)"}
         - runs-on: windows-2025-vs2026
-          build-system: {name: "Visual Studio 18 2026"}
+          build-system: {name: "Visual Studio 18 2026", vs-version-range: "[18.0,19.0)"}
 
     steps:
     - name: Setup MSVC (only for non-VS buildsystems)
@@ -84,6 +84,12 @@ jobs:
       if: startsWith(matrix.build-system.name, 'Visual Studio')
       run: |
         echo "GENERATOR_EXTRA_FLAGS=${{matrix.target-arch.vs-flags}}" >> $GITHUB_ENV
+        vs_instance_path=$(vswhere -version "${{ matrix.build-system.vs-version-range }}" -latest -property installationPath)
+        if [[ -z "$vs_instance_path" ]]; then
+          echo "No Visual Studio installation found for version range ${{ matrix.build-system.vs-version-range }}" >&2
+          exit 1
+        fi
+        echo "CMAKE_GENERATOR_INSTANCE=$vs_instance_path" >> $GITHUB_ENV
 
     - name: Setup toolset if we use Visual Studio Build System and Clang
       if: startsWith(matrix.build-system.name, 'Visual Studio') && matrix.toolchain.compiler == 'clang'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ windows-latest, windows-2025-vs2026 ]
+        runs-on: [ windows-2022, windows-2025-vs2026 ]
         toolchain:
         - { compiler: msvc, date-polyfill: 'ON', shared: 'ON' }
         - { compiler: msvc, date-polyfill: 'ON', shared: 'OFF' }
@@ -41,7 +41,7 @@ jobs:
         build-system:
         - {name: "Ninja"}
         include:
-        - runs-on: windows-latest
+        - runs-on: windows-2022
           build-system: {name: "Visual Studio 17 2022", vs-version-range: "[17.0,18.0)"}
         - runs-on: windows-2025-vs2026
           build-system: {name: "Visual Studio 18 2026", vs-version-range: "[18.0,19.0)"}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [main]
 concurrency:
   group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}
   cancel-in-progress: true
@@ -19,9 +19,9 @@ jobs:
       matrix:
         runs-on: [ windows-2022, windows-2025-vs2026 ]
         toolchain:
-        - { compiler: msvc, date-polyfill: 'ON', shared: 'ON' }
-        - { compiler: msvc, date-polyfill: 'ON', shared: 'OFF' }
-        - { compiler: msvc, date-polyfill: 'OFF', shared: 'ON' }
+        - {compiler: msvc, date-polyfill: 'ON', shared: 'ON'}
+        - {compiler: msvc, date-polyfill: 'ON', shared: 'OFF'}
+        - {compiler: msvc, date-polyfill: 'OFF', shared: 'ON'}
           # Temporary disable of clang on Windows because of https://github.com/llvm/llvm-project/issues/115990 and current msvc
           # build system on windows runners comes with this bugged version of clang)
           #- {compiler: clang, date-polyfill: 'ON', version: 18, shared: 'ON'}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [windows-latest]
+        runs-on: [windows-latest, windows-2025-vs2026]
         toolchain:
         - {compiler: msvc, date-polyfill: 'ON', shared: 'ON'}
         - {compiler: msvc, date-polyfill: 'ON', shared: 'OFF'}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: [main]
+    branches: [ main ]
 concurrency:
   group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}
   cancel-in-progress: true
@@ -17,11 +17,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [windows-latest, windows-2025-vs2026]
+        runs-on: [ windows-latest, windows-2025-vs2026 ]
         toolchain:
-        - {compiler: msvc, date-polyfill: 'ON', shared: 'ON'}
-        - {compiler: msvc, date-polyfill: 'ON', shared: 'OFF'}
-        - {compiler: msvc, date-polyfill: 'OFF', shared: 'ON'}
+        - { compiler: msvc, date-polyfill: 'ON', shared: 'ON' }
+        - { compiler: msvc, date-polyfill: 'ON', shared: 'OFF' }
+        - { compiler: msvc, date-polyfill: 'OFF', shared: 'ON' }
           # Temporary disable of clang on Windows because of https://github.com/llvm/llvm-project/issues/115990 and current msvc
           # build system on windows runners comes with this bugged version of clang)
           #- {compiler: clang, date-polyfill: 'ON', version: 18, shared: 'ON'}
@@ -36,11 +36,17 @@ jobs:
             msvc-dev-cmd: "win64"
           }
         config:
-        - {name: Debug}
-        - {name: Release}
+        - { name: Debug }
+        - { name: Release }
         build-system:
-        - {name: "Visual Studio 17 2022"}
-        - {name: "Ninja"}
+        - { name: "Visual Studio 17 2022" }
+        - { name: "Visual Studio 18 2026" }
+        - { name: "Ninja" }
+        exclude:
+        - runs-on: windows-latest
+          build-system: { name: "Visual Studio 18 2026" }
+        - runs-on: windows-2025-vs2026
+          build-system: { name: "Visual Studio 17 2022" }
 
     steps:
     - name: Setup MSVC (only for non-VS buildsystems)
@@ -122,7 +128,7 @@ jobs:
       run: |
         choco install opencppcoverage
         echo "TEST_COVERAGE_ACTIVATION=' -DENABLE_COVERAGE=ON'" >> $GITHUB_ENV
-      
+
     - name: Set CMake generator environment variable
       run: |
         echo "CMAKE_GENERATOR=${{ matrix.build-system.name }}" >> $GITHUB_ENV

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,12 +39,14 @@ jobs:
         - { name: Debug }
         - { name: Release }
         build-system:
-        - {name: "Ninja"}
-        include:
+        - { name: "Visual Studio 17 2022", vs-version-range: "[17.0,18.0)" }
+        - { name: "Visual Studio 18 2026", vs-version-range: "[18.0,19.0)" }
+        - { name: "Ninja" }
+        exclude:
         - runs-on: windows-2022
-          build-system: {name: "Visual Studio 17 2022", vs-version-range: "[17.0,18.0)"}
+          build-system: { name: "Visual Studio 18 2026" }
         - runs-on: windows-2025-vs2026
-          build-system: {name: "Visual Studio 18 2026", vs-version-range: "[18.0,19.0)"}
+          build-system: { name: "Visual Studio 17 2022" }
 
     steps:
     - name: Setup MSVC (only for non-VS buildsystems)

--- a/include/sparrow/list_array.hpp
+++ b/include/sparrow/list_array.hpp
@@ -187,7 +187,9 @@ namespace sparrow
             std::optional<std::unordered_set<ArrowFlag>>
                 flags = nullable ? std::optional<std::unordered_set<ArrowFlag>>{{ArrowFlag::NULLABLE}}
                                  : std::nullopt;
-            auto child_schemas = new ArrowSchema*[1]{new ArrowSchema(std::move(flat_schema))};
+
+            ArrowSchema** child_schemas = new ArrowSchema*[1];
+            child_schemas[0] = new ArrowSchema(std::move(flat_schema));
 
             return make_arrow_schema(
                 std::move(format),
@@ -210,7 +212,9 @@ namespace sparrow
         )
         {
             const repeat_view<bool> children_ownership{true, 1};
-            auto child_arrays = new ArrowArray*[1]{new ArrowArray(std::move(flat_arr))};
+
+            ArrowArray** child_arrays = new ArrowArray*[1];
+            child_arrays[0] = new ArrowArray(std::move(flat_arr));
             return make_arrow_array(
                 size,
                 null_count,

--- a/include/sparrow/map_array.hpp
+++ b/include/sparrow/map_array.hpp
@@ -568,7 +568,9 @@ namespace sparrow
         auto [entries_arr, entries_schema] = extract_arrow_structures(std::move(entries));
 
         const repeat_view<bool> children_ownership{true, 1};
-        auto child_schemas = new ArrowSchema*[1]{new ArrowSchema(std::move(entries_schema))};
+
+        ArrowSchema** child_schemas = new ArrowSchema*[1];
+        child_schemas[0] = new ArrowSchema(std::move(entries_schema));
 
         ArrowSchema schema = make_arrow_schema(
             std::string("+m"),
@@ -586,7 +588,9 @@ namespace sparrow
         arr_buffs.reserve(2);
         arr_buffs.emplace_back(std::move(validity_buffer));
         arr_buffs.emplace_back(std::move(list_offsets).extract_storage());
-        auto child_arrays = new ArrowArray*[1]{new ArrowArray(std::move(entries_arr))};
+
+        ArrowArray** child_arrays = new ArrowArray*[1];
+        child_arrays[0] = new ArrowArray(std::move(entries_arr));
 
         ArrowArray arr = make_arrow_array(
             static_cast<std::int64_t>(size),  // length

--- a/test/test_list_array.cpp
+++ b/test/test_list_array.cpp
@@ -119,7 +119,8 @@ namespace sparrow
             schema.metadata = nullptr;
             schema.flags = static_cast<int64_t>(ArrowFlag::NULLABLE);
             schema.n_children = 1;
-            schema.children = new ArrowSchema*[1]{new ArrowSchema(std::move(flat_schema))};
+            schema.children = new ArrowSchema*[1];
+            schema.children[0] = new ArrowSchema(std::move(flat_schema));
             schema.dictionary = nullptr;
             schema.release = &release_external_arrow_schema;
 
@@ -133,7 +134,8 @@ namespace sparrow
             buffers[1] = make_external_list_offsets_buffer(sizes);
             arr.buffers = const_cast<const void**>(reinterpret_cast<void**>(buffers));
             arr.n_children = 1;
-            arr.children = new ArrowArray*[1]{new ArrowArray(std::move(flat_arr))};
+            arr.children = new ArrowArray*[1];
+            arr.children[0] = new ArrowArray(std::move(flat_arr));
             arr.dictionary = nullptr;
             arr.release = &release_external_arrow_array;
 
@@ -154,7 +156,8 @@ namespace sparrow
             schema.metadata = nullptr;
             schema.flags = static_cast<int64_t>(ArrowFlag::NULLABLE);
             schema.n_children = 1;
-            schema.children = new ArrowSchema*[1]{new ArrowSchema(std::move(flat_schema))};
+            schema.children = new ArrowSchema*[1];
+            schema.children[0] = new ArrowSchema(std::move(flat_schema));
             schema.dictionary = nullptr;
             schema.release = &release_external_arrow_schema;
 
@@ -169,7 +172,8 @@ namespace sparrow
             buffers[2] = make_external_list_sizes_buffer(sizes);
             arr.buffers = const_cast<const void**>(reinterpret_cast<void**>(buffers));
             arr.n_children = 1;
-            arr.children = new ArrowArray*[1]{new ArrowArray(std::move(flat_arr))};
+            arr.children = new ArrowArray*[1];
+            arr.children[0] = new ArrowArray(std::move(flat_arr));
             arr.dictionary = nullptr;
             arr.release = &release_external_arrow_array;
 


### PR DESCRIPTION
Fix MSVC build failure caused by `new T*[N]{...}` brace-initialized array-new expressions.
